### PR TITLE
Added link to zwave util ref to references pg

### DIFF
--- a/reference-material.rst
+++ b/reference-material.rst
@@ -12,6 +12,7 @@ Reference Material
 	- `Event <https://graph.api.smartthings.com/ide/doc/event>`__	
 	- `Location <https://graph.api.smartthings.com/ide/doc/location>`__		
 	- `Mode <https://graph.api.smartthings.com/ide/doc/mode>`__		
-	- `State <https://graph.api.smartthings.com/ide/doc/state>`__			
+	- `State <https://graph.api.smartthings.com/ide/doc/state>`__
+- `Z-Wave Utility Reference <https://graph.api.smartthings.com/ide/doc/zwave-utils.html>`__
 
 	


### PR DESCRIPTION
I always have to go to the z-wave primer to find this link (we don't need no stinkin' bookmarks!) and it's a reference that is also written/maintained/hosted by ST, so it seemed sensible to link to it from the reference materials page.