### PR TITLE
Update state

### DIFF
--- a/smartapp-developers-guide/state.rst
+++ b/smartapp-developers-guide/state.rst
@@ -143,6 +143,8 @@ To avoid this type of scenario, you can use ``atomicState``. ``atomicState`` wri
 
   Use ``atomicState`` only if you are sure that using ``state`` will cause problems. 
 
+  It's also worth noting that you should **not** use both ``state`` and ``atomicState`` in the same SmartApp or Device Handler. Doing so will likely cause inconsistencies in in state values.
+
 Examples
 --------
 

--- a/smartapp-developers-guide/state.rst
+++ b/smartapp-developers-guide/state.rst
@@ -1,18 +1,65 @@
-State
-=====
+Storing Data
+============
 
-Recall that SmartApps are not always running, but rather execute according to a certain schedule or in response to events being triggered. But what if we need our SmartApp to retain some information between executions? 
+SmartApps and Device Handlers are all provided a ``state`` variable that will allow you to store data across executions.
 
-SmartApps are all provided a ``state`` variable that will allow you to store data across executions.
+In this guide, you will learn:
 
-Using SmartApp State
---------------------
+- How to store data across executions using the ``state`` property.
+- A basic understanding of how ``state`` works.
+- When ``state`` may not be the best solution, and what to use instead.
 
-To use SmartApp state, simply use the ``state`` variable that is injected into every SmartApp. You can think of it as a map that will persist its value across executions.
+.. contents::
 
-You can use SmartApp state to store strings, numbers, lists, boolean values, maps, etc. Behind the scenes, SmartThings serializes state data into JSON. This means that there are certain types that are not amenable to being stored in state. This is discussed further in the `State Limitations`_ section.
+Overview
+--------
 
-Typically SmartApps will use or update SmartApp state values in an event handler.
+Recall that SmartApps (and Device Handlers) are not always running, but rather execute according to a certain schedule or in response to events being triggered. But what if we need our application to retain some information between executions? We can use ``state`` to persist data across executions.
+
+Here's a quick example showing how to work with state:
+
+.. code-block:: groovy
+
+  state.myData = "some data"
+  log.debug "state.myData = ${state.myData}"
+
+  state.myCounter = state.myCounter + 1
+
+How it Works
+------------
+
+Each executing instance of a SmartApp or Device Handler has access to a simple, map-like storage mechanism through the ``state`` property.
+When a SmartApp executes, it populates the ``state`` property from the backing store. The application can then interact with it, through simple map-like operations. 
+
+When the application is finished executing, the values in ``state`` are written back to persistent storage. 
+
+The contents of ``state`` are stored as a string, in JSON format. This means that anything stored in ``state`` must be serializable to JSON. 
+
+.. tip::
+
+  State is stored in JSON format. For most data types this works fine, but for more complex object types this may cause issues.
+
+  This is particularly worth noting when working with dates. If you need to store time information, consider using an epoch time stamp, conveniently available via the ``now()`` method:
+
+  .. code-block:: groovy
+
+    def installed() {
+      state.installedAt = now()
+    }
+
+    def someEventHandler(evt) {
+      def millisSinceInstalled = now() - state.installedAt
+      log.debug "this app was installed ${millisSinceInstalled / 1000} seconds ago"
+
+      // you can also create a Date object back from epoch time:
+      log.debug "this app was installed at ${new Date(state.installedAt)}"
+    }
+
+Using State
+-----------
+
+You can use ``state`` to store strings, numbers, lists, booleans, maps, etc. 
+To use ``state``, simply use the ``state`` variable that is injected into every SmartApp and Device Handler. You can think of it as a map that will persist its value across executions.
 
 As usual, the best way to describe code is by showing code itself. 
 
@@ -57,26 +104,32 @@ As usual, the best way to describe code is by showing code itself.
       }
     }  
 
-State Limitations
------------------
+Atomic State
+------------
 
-SmartApp state is stored in JSON format. For most data types this works fine, but for more complex object types this may cause issues.
+Since ``state`` is initialized from persistent storage when a SmartApp or Device Handler executes, and is written to storage only when the application is done executing, there is the possibility that another execution *could* happen within that time window, and cause the values stored in ``state`` to appear inconsistent.
 
-This is particularly worth noting when working with dates. If you need to store time information, consider using an epoch time stamp, conveniently available via the ``now()`` method:
+Consider this scenario:
 
-.. code-block:: groovy
+#. User has "Some FancyPants SmartApp" installed. It subscribes to every switch in the user's house, and does something really awesome (and time-consuming) when a switch is turned on or off. It uses ``state``, and the current contents of ``state.awesomeVar`` is "I haven't executed in a while".
 
-  def installed() {
-    state.installedAt = now()
-  }
+#. A switch is turned on. An execution (let's call it "Execution 1") of the app is triggered, and all the state information is loaded from external storage into the ``state`` property. The app sets ``state.awesomeVar = "I'm Execution 1!"``.
 
-  def someEventHandler(evt) {
-    def millisSinceInstalled = now() - state.installedAt
-    log.debug "this app was installed ${millisSinceInstalled / 1000} seconds ago"
+#. Another switch is turned on *before* "Execution 1" is finished. We'll call this "Execution 2". The application reads the value of ``state.awesomeVar``, and sees that it is "I haven't executed in a while" (not the value that was set by "Execution 1"!). This execution sets ``state.awesomeVar = "I'm Execution 2"``.
 
-    // you can also create a Date object back from epoch time:
-    log.debug "this app was installed at ${new Date(state.installedAt)}"
-  }
+#. "Execution 1" finishes. The contents of ``state`` are written back to external storage, including the value in ``state.awesomeVar`` ("I'm execution 1!").
+
+#. "Execution 2" finishes. The contents of ``state`` are written to external storage ("I'm execution 2!").
+
+#. "Execution 3" starts, and reads the ``state.awesomeVar`` value. It sees the value of "I'm Execution 2".
+
+To avoid race conditions like this, you can use ``atomicState``. ``atomicState`` writes to the data store when a value is *set*, and reads from the data store when a value is *read* - not just when the application execution initializes and completes. 
+
+.. important::
+  
+  Using ``atomicState`` instead of ``state`` incurs a higher performance cost, since external storage is touched on read and write operations, not just when the application is initialized or done executing.
+
+  Use ``atomicState`` only if you are sure that using ``state`` will cause problems. 
 
 Examples
 --------

--- a/smartapp-developers-guide/state.rst
+++ b/smartapp-developers-guide/state.rst
@@ -131,7 +131,11 @@ Because "Execution 1" hasn't finished executing by the time that "Execution 2" b
 
 Additionally, because the contents of ``state`` are only persisted when execution is complete, it's also possible to inadvertantly overwrite values (last finished execution "wins").
 
-To avoid this type of scenario, you can use ``atomicState``. ``atomicState`` writes to the data store when a value is *set*, and reads from the data store when a value is *read* - not just when the application execution initializes and completes. 
+To avoid this type of scenario, you can use ``atomicState``. ``atomicState`` writes to the data store when a value is *set*, and reads from the data store when a value is *read* - not just when the application execution initializes and completes. You use it just as you would use ``state``:
+
+.. code-block:: groovy
+
+  atomicState.counter = atomicState.counter + 1.
 
 .. important::
   

--- a/smartapp-developers-guide/state.rst
+++ b/smartapp-developers-guide/state.rst
@@ -29,15 +29,19 @@ How it Works
 ------------
 
 Each executing instance of a SmartApp or Device Handler has access to a simple, map-like storage mechanism through the ``state`` property.
-When a SmartApp executes, it populates the ``state`` property from the backing store. The application can then interact with it, through simple map-like operations. 
+When an application executes, it populates the ``state`` property from the backing store. The application can then interact with it, through simple map-like operations. 
 
 When the application is finished executing, the values in ``state`` are written back to persistent storage. 
+
+.. important::
+
+  When an application stores data in ``state``, or reads from it, it is only modifying (or querying) the local ``state`` instance variable within the running SmartApp or Device Handler. Only when the application is done executing are the values written to persistent storage.
 
 The contents of ``state`` are stored as a string, in JSON format. This means that anything stored in ``state`` must be serializable to JSON. 
 
 .. tip::
 
-  State is stored in JSON format. For most data types this works fine, but for more complex object types this may cause issues.
+  State is stored in JSON format; for most data types this works fine, but for more complex object types this may cause issues.
 
   This is particularly worth noting when working with dates. If you need to store time information, consider using an epoch time stamp, conveniently available via the ``now()`` method:
 
@@ -109,21 +113,25 @@ Atomic State
 
 Since ``state`` is initialized from persistent storage when a SmartApp or Device Handler executes, and is written to storage only when the application is done executing, there is the possibility that another execution *could* happen within that time window, and cause the values stored in ``state`` to appear inconsistent.
 
-Consider this scenario:
+Consider the scenario of a SmartApp that keeps a counter of executions. Each time the SmartApp executes, it increments the counter by 1. Assume that the initial value of ``state.counter`` is ``0``.
 
-#. User has "Some FancyPants SmartApp" installed. It subscribes to every switch in the user's house, and does something really awesome (and time-consuming) when a switch is turned on or off. It uses ``state``, and the current contents of ``state.awesomeVar`` is "I haven't executed in a while".
+1. An execution ("Execution 1") occurs, and increments ``state.counter`` by one:
 
-#. A switch is turned on. An execution (let's call it "Execution 1") of the app is triggered, and all the state information is loaded from external storage into the ``state`` property. The app sets ``state.awesomeVar = "I'm Execution 1!"``.
+.. code-block:: groovy
 
-#. Another switch is turned on *before* "Execution 1" is finished. We'll call this "Execution 2". The application reads the value of ``state.awesomeVar``, and sees that it is "I haven't executed in a while" (not the value that was set by "Execution 1"!). This execution sets ``state.awesomeVar = "I'm Execution 2"``.
+  state.counter = state.counter + 1 // counter == 1
 
-#. "Execution 1" finishes. The contents of ``state`` are written back to external storage, including the value in ``state.awesomeVar`` ("I'm execution 1!").
+2. Another execution ("Execution 2") occurs *before "Execution 1" has finished*. It reads ``state.counter`` and increments it by one. 
 
-#. "Execution 2" finishes. The contents of ``state`` are written to external storage ("I'm execution 2!").
+.. code-block:: groovy
 
-#. "Execution 3" starts, and reads the ``state.awesomeVar`` value. It sees the value of "I'm Execution 2".
+  state.counter = state.counter + 1 // counter == 1!!!
 
-To avoid race conditions like this, you can use ``atomicState``. ``atomicState`` writes to the data store when a value is *set*, and reads from the data store when a value is *read* - not just when the application execution initializes and completes. 
+Because "Execution 1" hasn't finished executing by the time that "Execution 2" begins, the value of ``counter`` is still 0!
+
+Additionally, because the contents of ``state`` are only persisted when execution is complete, it's also possible to inadvertantly overwrite values (last finished execution "wins").
+
+To avoid this type of scenario, you can use ``atomicState``. ``atomicState`` writes to the data store when a value is *set*, and reads from the data store when a value is *read* - not just when the application execution initializes and completes. 
 
 .. important::
   


### PR DESCRIPTION
The current documentation for using state does not adequately discuss how it works, or discuss atomicState at all.

This PR includes:
* Updating guide title from "State" (implementation specific) to "Storing Data" (hopefully more meaningful to those who don't already know what "state" is).
* Add information about how state works at a high level (read from storage on initialization, and written back after execution completion).
* Add scenario of two concurrently executing installed SmartApps trying to use the same state variable.
* Discuss atomicState; why use it, when to use it, and how to use it.

/cc @beckje01 can you take a peek at the updates here? 