### PR TITLE
adding clarification on zigbee device handler doc

### DIFF
--- a/device-type-developers-guide/building-zigbee-device-handlers.rst
+++ b/device-type-developers-guide/building-zigbee-device-handlers.rst
@@ -54,6 +54,8 @@ we are using is formatted in an Unsigned 16-bit integer (0x21) with the
 payload being in 1/10th of a second. In this case the payload ({1400})
 translates to 2 seconds.
 
+.. note:: How does a payload of 1400 translate to 2 seconds? The value 1400 is actually a little endian hex string. It translates into an integer value of 0x0014, which is decimal value 20. Finally, 20 * 1/10 of a second equals 2 seconds.
+
 +-------------------------------+-----------------------------+
 | Component                     | Description                 |
 +===============================+=============================+
@@ -65,9 +67,9 @@ translates to 2 seconds.
 +-------------------------------+-----------------------------+
 |8                              |Cluster                      |
 +-------------------------------+-----------------------------+
-|10                             |Attribute Set                |
+|0x10                           |Attribute Set                |
 +-------------------------------+-----------------------------+
-|21                             |Data Type                    |
+|0x21                           |Data Type                    |
 +-------------------------------+-----------------------------+
 |{1400}                         |Payload                      |
 +-------------------------------+-----------------------------+


### PR DESCRIPTION
adding a note that describes how 1400 payload translates to 2 seconds in the "write" section of the zigbee device handler guide.