### PR TITLE
Simplify the docs organization. Add captions to the toc to categorize…

### DIFF
--- a/cloud-and-lan-connected-device-types-developers-guide/index.rst
+++ b/cloud-and-lan-connected-device-types-developers-guide/index.rst
@@ -1,7 +1,7 @@
 .. _cloud_lan_device_type_guide:
 
-Cloud and LAN Connected Developer's Guide
-=========================================
+Cloud and LAN-Connected Devices
+===============================
 
 Cloud and LAN connected devices are devices that use either a 3rd party service, like the Ecobee thermostat, or
 communicate over the LAN (local area network) like the Sonos system. These devices require a unique implementation of

--- a/conf.py
+++ b/conf.py
@@ -23,7 +23,7 @@ import os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
-    
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -110,7 +110,9 @@ html_theme = 'default'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'sticky_navigation': True
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -255,7 +257,7 @@ texinfo_documents = [
 
 def setup(app):
   app.add_stylesheet("custom.css")
-  
+
 # Documents to append as an appendix to all manuals.
 #texinfo_appendices = []
 

--- a/device-type-developers-guide/index.rst
+++ b/device-type-developers-guide/index.rst
@@ -1,15 +1,15 @@
 .. _device_type_dev_guide:
 
-Device Handler Developer's Guide
-=============================
+Device Handlers
+===============
 
-Device Handlers (sometimes also referred to as Device Type Handlers, or SmartDevices), are the virtual representation of a physical device. 
+Device Handlers (sometimes also referred to as Device Type Handlers, or SmartDevices), are the virtual representation of a physical device.
 
-If you are new to writing device handlers, start with the :doc:`quick-start`. 
+If you are new to writing device handlers, start with the :doc:`quick-start`.
 
 After that, read the :doc:`overview` for a broad discussion about device handlers and where they fit in the SmartThings architecture.
 
-The rest of the guide discusses the various components of device handlers.
+The rest of the guide discusses the various components of Device Handlers primarily targeted for hub-connected (ZigBee or Z-Wave) devices (though the common Device Handler principles and patterns apply to other devices as well).
 
 .. note::
 
@@ -20,8 +20,8 @@ Table of Contents:
 
 .. toctree::
    :maxdepth: 3
-           
-   quick-start    
+
+   quick-start
    overview
    simulator-metadata
    definition-metadata

--- a/index.rst
+++ b/index.rst
@@ -6,144 +6,39 @@
 SmartThings Developer Documentation
 ===================================
 
-.. note::
-
-    This documentation is a work in progress. Bear with us as we fill in some of the gaps, add clarifications, and expand out the content. It may mean that bookmarks break as we iterate and continually improve our documentation.
-
-    We appreciate your understanding and patience as we work to improve our developer experience!
-
-
 Welcome to the SmartThings developer documentation. Here you will find information about creating for the SmartThings platform.
 
-This documentation is organized into a few different sections:
+This documentation is a work in progress. As we fill in gaps, add clarifications, and expand content, we will make every effort to not break existing bookmarks.
 
-:doc:`getting-started`
-    Get up and running quickly with the SmartThings platform. Start here if this is your first time developing for SmartThings.
+.. tip::
 
-:doc:`introduction/index`
-    This chapter discusses some of the core SmartThings concepts, architecture, and how developers can create with SmartThings. It also introduces the SmartThings programming language - Groovy.
-
-:doc:`tools-and-ide/index`
-    This guide will teach you how to use the IDE to manage your account, and build and test your custom code.
-
-:doc:`smartapp-developers-guide/index`
-    This guide is all about developing SmartApps. It is primarily focused on event-based SmartApps.
-
-:doc:`device-type-developers-guide/index`
-    This guide will teach you what a Device Handler is, why they are important, and how to develop one.
-
-:doc:`cloud-and-lan-connected-device-types-developers-guide/index`
-    This guide covers developing with Cloud-connected and LAN devices.
-
-:doc:`smartapp-web-services-developers-guide/index`
-    This guide covers creating a SmartApp that exposes its own RESTful endpoints.
-
-:doc:`arduino/index`
-    This guide discusses developing for the Arduino using our SmartThings Shield for Arduino.
-
-:doc:`capabilities-reference`
-    This is where you find information on all the supported SmartThings capabilities.
-
-:doc:`ref-docs/reference`
-    This is the detailed API documentation for the various SmartThings objects.
-
-
-.. _Getting Started: getting-started.html
-.. _Introduction: introduction/index.html
-.. _SmartApp Guide: smartapp-developers-guide/index.html
-.. _Device Handler Guide: device-type-developers-guide/index.html
-.. _Cloud and LAN-Connected Guide: cloud-and-lan-connected-device-types-developers-guide/index.html
-.. _SmartApp Web Services Guide: smartapp-web-services-developers-guide/index.html
-.. _Arduino Guide: arduino/index.html
-.. _Capabilities Reference: capabilities-reference.html
-.. _API Documentation: ref-docs/reference.html
-
-Find a bug, typo, or just want to make an improvement? This documentation is open source and available on `GitHub <https://github.com/SmartThingsCommunity/Documentation/>`__. We like contributions!
+    Find a bug, typo, or just want to make an improvement? This documentation is open source and available on `GitHub <https://github.com/SmartThingsCommunity/Documentation/>`__. We like contributions!
 
 Contents
 --------
 
-Getting Started
-~~~~~~~~~~~~~~~
-
 .. toctree::
+   :caption: Getting Started
    :maxdepth: 2
 
    getting-started
 
-Introduction
-~~~~~~~~~~~~
-
-.. toctree::
-   :maxdepth: 3
-
-   introduction/index
-
-Tools and IDE
-~~~~~~~~~~~~~
-
-.. toctree::
-    :maxdepth: 3
-
-    tools-and-ide/index
-
-SmartApp Developer's Guide
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. toctree::
-	:maxdepth: 3
-
-	smartapp-developers-guide/index
-
-Device Handler Developer's Guide
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. toctree::
-	:maxdepth: 3
-
-	device-type-developers-guide/index
-
-Cloud-Connected & LAN-Connected Device Type Developer's Guide
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. toctree::
-	:maxdepth: 3
-
-	cloud-and-lan-connected-device-types-developers-guide/index
-
-SmartApp Web Services Developer's Guide
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. toctree::
-	:maxdepth: 3
-
-	smartapp-web-services-developers-guide/index
-
-Arduino ThingShield
-~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
    :maxdepth: 2
+   :caption: Guides
 
+   introduction/index
+   tools-and-ide/index
+   smartapp-developers-guide/index
+   smartapp-web-services-developers-guide/index
+   device-type-developers-guide/index
+   cloud-and-lan-connected-device-types-developers-guide/index
    arduino/index
-
-Capabilities Reference
-~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
+    :caption: Reference
 
     capabilities-reference
-
-API Documentation
-~~~~~~~~~~~~~~~~~
-
-.. toctree::
-    :maxdepth: 3
-
     ref-docs/reference
-
-Search
-======
-
-* :ref:`search`

--- a/smartapp-developers-guide/index.rst
+++ b/smartapp-developers-guide/index.rst
@@ -1,7 +1,7 @@
 .. _smartapp_dev_guide:
 
-SmartApp Developer's Guide
-==========================
+SmartApps
+=========
 
 SmartApps are Groovy-based programs that allow a user to tap into the capabilities of their devices to automate their lives.
 

--- a/smartapp-web-services-developers-guide/index.rst
+++ b/smartapp-web-services-developers-guide/index.rst
@@ -1,23 +1,23 @@
 .. _smartapp_web_services_guide:
 
-SmartApp Web Services Developer's Guide
-=======================================
+Web Services SmartApps
+======================
 
 SmartApps may themselves be a web service, exposing a URL and any defined endpoints.
 
 This allows external applications to make web API calls to a SmartApp, and get information about, or control, end devices.
 
-To understand how Web Services SmartApps work, including the security measures in place, read the :ref:`web_services_smartapps_overview` guide. 
+To understand how Web Services SmartApps work, including the security measures in place, read the :ref:`web_services_smartapps_overview` guide.
 
 For a step-by-step tutorial creating a Web Services SmartApp, read the SmartApp as Web Service tutorial. It's organized into two parts:
 
-- :ref:`smartapp_as_web_service_part_1`, will walk you through a simple SmartApp that exposes endpoints, and use the simulator and curl to test making API calls to your SmartApp. 
+- :ref:`smartapp_as_web_service_part_1`, will walk you through a simple SmartApp that exposes endpoints, and use the simulator and curl to test making API calls to your SmartApp.
 - :ref:`smartapp_as_web_service_part_2` will guide you through the steps an external application would take to integrate with SmartThings.
 
 **Contents:**
 
 .. toctree:: Contents
-               
+
    overview
    tutorial-part1
    tutorial-part2


### PR DESCRIPTION
Simplify/clarify the docs organization.

This categorizes the docs into "getting started", "guides", and "reference". We can add additional categories as we go (e.g., cookbook, examples/tutorials, etc).