### PR TITLE
updating incorrect example for zigbee wattr method.

### DIFF
--- a/device-type-developers-guide/building-zigbee-device-handlers.rst
+++ b/device-type-developers-guide/building-zigbee-device-handlers.rst
@@ -53,7 +53,7 @@ the attribute that defines on and off transition time (0x10). The value
 we are using is formatted in an Unsigned 16-bit integer (0x21) with the
 payload being in 1/10th of a second. In this case the payload ({0014})
 translates to 2 seconds. Breaking the payload down we see that the hex value
-of 0x0014 equals the decimal value of 20. 20 * 1/10 of a second equals 2 Seconds.
+of 0x0014 equals the decimal value of 20. 20 * 1/10 of a second equals 2 seconds.
 
 .. note::
   The payload in the example above, {0014}, is a hex string. The length of the payload must be two times the length of the data type. For example, if the datatype is 16-bit, then the payload should be 4 hex digits.

--- a/device-type-developers-guide/building-zigbee-device-handlers.rst
+++ b/device-type-developers-guide/building-zigbee-device-handlers.rst
@@ -43,7 +43,7 @@ Write sets an attribute of a ZigBee device and is formatted like this:
 .. code-block:: groovy
 
     def configure() {
-            "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {1400}"
+            "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {0014}"
         }
 
 In this example (from the "ZigBee Dimmer" device type) we are writing to
@@ -51,10 +51,12 @@ an attribute to set the amount of time it takes for a light to fully dim
 on and off. Here we are using the Level Control Cluster (8) to write to
 the attribute that defines on and off transition time (0x10). The value
 we are using is formatted in an Unsigned 16-bit integer (0x21) with the
-payload being in 1/10th of a second. In this case the payload ({1400})
-translates to 2 seconds.
+payload being in 1/10th of a second. In this case the payload ({0014})
+translates to 2 seconds. Breaking the payload down we see that the hex value
+of 0x0014 equals the decimal value of 20. 20 * 1/10 of a second equals 2 Seconds.
 
-.. note:: How does a payload of 1400 translate to 2 seconds? The value 1400 is actually a little endian hex string. It translates into an integer value of 0x0014, which is decimal value 20. Finally, 20 * 1/10 of a second equals 2 seconds.
+.. note::
+  The payload in the example above, {0014}, is a hex string. The length of the payload must be two times the length of the data type. For example, if the datatype is 16-bit, then the payload should be 4 hex digits.
 
 +-------------------------------+-----------------------------+
 | Component                     | Description                 |
@@ -71,7 +73,7 @@ translates to 2 seconds.
 +-------------------------------+-----------------------------+
 |0x21                           |Data Type                    |
 +-------------------------------+-----------------------------+
-|{1400}                         |Payload                      |
+|{0014}                         |Payload                      |
 +-------------------------------+-----------------------------+
 
 Command

--- a/device-type-developers-guide/zigbee-primer.rst
+++ b/device-type-developers-guide/zigbee-primer.rst
@@ -103,7 +103,8 @@ can need specific data type that the payload is in. In this example the
 An example of a Write Attribute that would set the transition time from
 on to off of a dimmer look like this:
 
-``"st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {1400}”``
+``"st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {0014}”``
 
-The 1400 means the light takes 1400 1/10ths of a second to turn on and
-off.
+In this case the payload ({0014}) translates to 2 seconds. Breaking the payload 
+down we see that the hex value of 0x0014 equals the decimal value of 20. 20 *
+1/10 of a second equals 2 Seconds.

--- a/device-type-developers-guide/zigbee-primer.rst
+++ b/device-type-developers-guide/zigbee-primer.rst
@@ -105,6 +105,6 @@ on to off of a dimmer look like this:
 
 ``"st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {0014}”``
 
-In this case the payload ({0014}) translates to 2 seconds. Breaking the payload 
+In this case the payload ({0014}) translates to 2 seconds. Breaking the payload
 down we see that the hex value of 0x0014 equals the decimal value of 20. 20 *
-1/10 of a second equals 2 Seconds.
+1/10 of a second equals 2 seconds.

--- a/smartapp-developers-guide/preferences-and-settings.rst
+++ b/smartapp-developers-guide/preferences-and-settings.rst
@@ -112,7 +112,7 @@ Sections can be created in a few different ways:
 
 *section(String sectionTitle){}*
 
-.. code-block:: groovy::
+.. code-block:: groovy
 
     preferences {
         // section with title


### PR DESCRIPTION
@tpmanley Here is the updated example. Let me know if this looks correct to you.