### PR TITLE
only single quotes can be used to interpolate string vals in the tiles definition

### DIFF
--- a/device-type-developers-guide/tiles-metadata.rst
+++ b/device-type-developers-guide/tiles-metadata.rst
@@ -136,6 +136,17 @@ Let's consider a switch tile definition example:
               icon: "st.switches.switch.on", backgroundColor: "#E60000"
     }
 
+.. important::
+
+    Notice anything strange about the ``label`` value for state? It appears to be using Groovy's string interpolation syntax (``${}``), but with a **single quote**. In Groovy, String interpolation is only possible for strings defined in double quotes. So, what gives?
+
+    When the SmartThings platform executes the ``tiles()`` method you have defined, it doesn't yet know anything about the actual devices. Only later, when the device details screen is rendered in the mobile client, does the platform know information about the specific devices.
+
+    So, we use single quotes for the label (``${name}``) because the platform can then manually substitute the actual value later, when it is available.
+
+    Long story short - the above is not a typo. Use single quotes for interpolated string values in the tiles definition.
+
+
 The "switch" attribute specifies two possible values - "on" and "off". We define a state for each possible value. The first argument to the ``state()`` method should be the value of the attribute this state applies to (there is an exception to this rule discussed below).
 
 When the switch is off, and the user presses on the tile on their mobile device, we want to turn the switch on. We specify this action using the ``action`` parameter.


### PR DESCRIPTION
A community member was (understandably!) confused that string interpolations in the tiles method use single quotes, and fails with double quotes. This is not as Groovy's string interpolation is defined (only works with double quotes), so causes confusion.

I added a clarifying tip near this code example that was causing confusion. What we really need is an entire lifecycle diagram/overview as discussed previously, but given the current docs backlog I don't want this clarification to go undocumented until such time as we find bandwidth/priority for the lifecycle diagram.

@mrnohr would be good for you to review/comment/suggest. 