### PR TITLE
Clarify that child SmartApps will validate parent on save.

### DIFF
--- a/smartapp-developers-guide/parent-child-smartapps.rst
+++ b/smartapp-developers-guide/parent-child-smartapps.rst
@@ -41,6 +41,12 @@ In the SmartApp you wish to serve as the child, specify the ``parent`` option in
         ...
     )
 
+.. note::
+
+    When you save the child SmartApp, the platform will validate that a parent SmartApp with the namespace and name as specified in the ``parent`` option exists. If it does not, an error will be raised.
+
+    Either make sure your parent SmartApp has been saved first, or come back and add the ``parent`` option after your parent SmartApp has been saved.
+
 Communicating Between Parent and Children
 -----------------------------------------
 


### PR DESCRIPTION
Clarify that when trying to save a SmartApp that has the `parent` option in the definition (because it's a child SmartApp), the platform will attempt to find a SmartApp with the given namespace/name. If one is not found, an error will occur.

There's a whole section that will need to be updated around the install lifecycle for parent/child SmartApps as well (so that we know when each install()/updated() is called, when parent/child references are available), etc.