### PR TITLE
Fix broken Z-Wave response() example

### DIFF
--- a/device-type-developers-guide/building-z-wave-device-handlers.rst
+++ b/device-type-developers-guide/building-z-wave-device-handlers.rst
@@ -156,12 +156,12 @@ string and supplies a HubAction:
 
     def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd)
     {
-        sendEvent(descriptionText: "${device.displayName} woke up", displayed: false)
-        def result = []
-        result << zwave.batteryV1.batteryGet().format()
-        result << "delay 1200"
-        result << zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-        response(result) // returns the result of reponse()
+        def event = createEvent(descriptionText: "${device.displayName} woke up", displayed: false)
+        def cmds = []
+        cmds << zwave.batteryV1.batteryGet().format()
+        cmds << "delay 1200"
+        cmds << zwave.wakeUpV1.wakeUpNoMoreInformation().format()
+        [event, response(cmds)] // return a list containing the event and the result of response()
     }
 
 The above example uses the ``response`` helper to send Z-Wave commands


### PR DESCRIPTION
It doesn't appear to work to return only a HubAction from parse(), it only processes hub actions that are returned as part of a list. Returning [event, response(cmds)] is the current best practice for this kind of handler.