### PR TITLE
Update web services

### DIFF
--- a/ref-docs/smartapp-ref.rst
+++ b/ref-docs/smartapp-ref.rst
@@ -515,6 +515,32 @@ Executes an HTTP DELETE request and passes control to the specified closure. The
 
 ----
 
+.. _smartapp_http_error:
+
+httpError()
+~~~~~~~~~~~
+
+Throws a ``SmartAppException`` with the specified status code and message.
+
+This should be used to send an HTTP error to any calling client.
+
+**Signature:**
+    ``def httpError(Integer status, message)``
+
+**Parameters:**
+    `Integer`_ status - The HTTP error code to send.
+    message - the error message.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def someMethod() {
+        httpError(400, "something went wrong")
+    }
+
+----
+
 httpGet()
 ~~~~~~~~~
 
@@ -902,6 +928,45 @@ Parses a Base64-encoded LAN message received from the hub into a map with header
     xml      `GPathResult`_ the request body as a `GPathResult`_ object
     xmlError `String`_      error message from parsing the body, if any
     ======== ============== ===================
+
+----
+
+.. _smartapp_render:
+
+render()
+~~~~~~~~
+
+Returns a HTTP response to the calling client with the options specified.
+
+**Signature:**
+    ``def render(Map options)``
+
+**Parameters:**
+    `Map`_ options - the options for what is returned to the client:
+
+    =========== ===========
+    option      description
+    =========== ===========
+    contentType The value of the "Content-Type" request header. "application/json" if not specified.
+    status      The HTTP status of the response. 200 if not specified.
+    data        Required. The data for this response.
+    =========== ===========
+
+**Example:**
+
+.. code-block:: groovy
+
+    def someMethod() {
+        def html = """
+            <!DOCTYPE HTML>
+            <html>
+                <head><title>Some Title</title></head>
+                <body><p>Some Text</p></body>
+            </html>
+        """
+
+        render contentType: "text/html", data: html
+    }
 
 ----
 

--- a/smartapp-web-services-developers-guide/authorization.rst
+++ b/smartapp-web-services-developers-guide/authorization.rst
@@ -115,7 +115,6 @@ A successful response will look like this:
 
     {
         "oauthClient": {
-            "clientSecret": "CLIENT-SECRET",
             "clientId": "CLIENT-ID"
         },
         "uri": "BASE-URL/api/smartapps/installations/INSTALLATION-ID",

--- a/smartapp-web-services-developers-guide/authorization.rst
+++ b/smartapp-web-services-developers-guide/authorization.rst
@@ -1,0 +1,163 @@
+.. _webservices_authorization:
+
+Authorization
+=============
+
+To make REST requests to a SmartApp, the client must establish a trusted relationship using an implementation of the OAuth2 Authorization Code Flow.
+
+The general flow is:
+
+#. Request an authorization code.
+#. Use the code to request an access token.
+#. Get the endpoint URI for the SmartApp.
+#. Make REST calls to the SmartApp using the endpoint URI.
+
+.. note::
+
+    Regardless of the server the SmartApp is actually published to, ``https://graph.api.smartthings.com`` should be used to obtain the authorization code, access token, and endpoints.
+
+----
+
+Get Authorization Code
+----------------------
+
+To obtain an authorization code, make a ``GET`` request to ``https://graph.api.smartthings.com/oauth/authorize``:
+
+.. code-block:: bash
+
+    GET https://graph.api.smartthings.com/oauth/authorize?
+            response_type=code&
+            client_id=YOUR-SMARTAPP-CLIENT-ID&
+            scope=app&
+            redirect_uri=YOUR-SERVER-URI
+
+
+The following parameters are required:
+
+============== ===========
+parameter      value
+============== ===========
+response_type  Use ``code`` to obtain the authorization code.
+client_id      The OAuth client ID of the SmartApp.
+scope          This should always be "app" for this authorization flow.
+redirect_uri   The URI of your server that will receive the authorization code.
+============== ===========
+
+This will require the user to log in with their SmartThings account credentials, choose a Location, and select what devices may be accessed by the third party.
+
+The authorization code expires 24 hours after issue.
+
+----
+
+Get Access Token
+----------------
+
+Use the code you received to obtain the access token:
+
+You can use a ``GET`` or ``POST`` request, though ``POST`` is preferred.
+
+.. code-block:: bash
+
+    POST https://graph.api.smartthings.com/oauth/token
+
+The following request parameters are required:
+
+=================== ===========
+parameter           value
+=================== ===========
+grant_type          This is always "code" for this flow.
+authorization_code  The code you received.
+client_id           The client ID for the SmartApp
+client_secret       The client secret for the SmartApp
+redirect_uri        The URI of the server that will receive the token. This must match the URI you used to obtain the authorization code.
+=================== ===========
+
+.. note::
+
+    Issuing a `GET` request to obtain the access token also works, but `POST` is preferred.
+
+A successful response will look like this:
+
+.. code::
+
+    {
+      "access_token": "XXXXXXXXXXXX",
+      "expires_in": 1576799999,
+      "token_type": "bearer"
+    }
+
+The ``expires_in`` response is the time, in seconds from now, that this token will expire.
+
+Once you have the token, it must be stored securely in the application.
+
+.. note::
+
+    At this time, SmartThings issues a long-lived access token, with no refresh tokens.
+    The expiration date of the token is 50 years from issue.
+
+    Refresh tokens will be provided in a future release.
+
+----
+
+Get SmartApp Endpoints
+----------------------
+
+You can use the token to request the callable endpoints of the SmartApp, by making a ``GET`` request to ``https://graph.api.smartthings.com/api/smartapps/endpoints``.
+The access token should be supplied via a ``Authorize: Bearer`` header:
+
+.. code-block:: bash
+
+    GET -H "Authorize: Bearer ACCESS-TOKEN" "https://graph.api.smartthings.com/api/smartapps/endpoints"
+
+A successful response will look like this:
+
+.. code-block:: javascript
+
+    {
+        "oauthClient": {
+            "clientSecret": "CLIENT-SECRET",
+            "clientId": "CLIENT-ID"
+        },
+        "uri": "BASE-URL/api/smartapps/installations/INSTALLATION-ID",
+        "base_url": "BASE-URL",
+        "url": "/api/smartapps/installations/INSTALLATION-ID"
+    }
+
+
+.. important::
+
+    The ``base_url`` (and base URL of the ``uri``) will vary depending upon the server the SmartApp is being installed to.
+
+    SmartApps may be installed into any number of servers depending upon the location of the end-user.
+    You should always use the ``uri`` and ``base_url`` to find the location this SmartApp can be reached at.
+
+    Do not assume that the SmartApp will be installed on ``https://graph.api.smartthings.com``.
+
+----
+
+Make REST Calls
+---------------
+
+Using the ``uri`` returned from ``/api/smartapps/endpoints``, you can then make REST calls the SmartApp.
+
+Simply append any paths your SmartApp declares in its ``mappings`` to make the appropriate request.
+
+For example, assuming a ``mappings`` definition like this:
+
+.. code-block:: groovy
+
+    mappings {
+        path("/switches") {
+            action: [GET: "getSwitches"]
+        }
+    }
+
+    def getSwitches() {
+        // ...
+    }
+
+And a URI of ``https://graph.api.smartthings.com/api/smartapps/installations/12345``, you can make a request to the ``/switches`` endpoint like this:
+
+.. code-block:: bash
+
+    curl -H "Authorization: Bearer ACCESS-TOKEN" -X GET "https://graph.api.smartthings.com/api/smartapps/installations/12345/switches"

--- a/smartapp-web-services-developers-guide/index.rst
+++ b/smartapp-web-services-developers-guide/index.rst
@@ -7,17 +7,13 @@ SmartApps may themselves be a web service, exposing a URL and any defined endpoi
 
 This allows external applications to make web API calls to a SmartApp, and get information about, or control, end devices.
 
-To understand how Web Services SmartApps work, including the security measures in place, read the :ref:`web_services_smartapps_overview` guide.
-
-For a step-by-step tutorial creating a Web Services SmartApp, read the SmartApp as Web Service tutorial. It's organized into two parts:
-
-- :ref:`smartapp_as_web_service_part_1`, will walk you through a simple SmartApp that exposes endpoints, and use the simulator and curl to test making API calls to your SmartApp.
-- :ref:`smartapp_as_web_service_part_2` will guide you through the steps an external application would take to integrate with SmartThings.
-
 **Contents:**
 
 .. toctree::
 
    overview
+   smartapp
+   authorization
+   rate-limiting
    tutorial-part1
    tutorial-part2

--- a/smartapp-web-services-developers-guide/overview.rst
+++ b/smartapp-web-services-developers-guide/overview.rst
@@ -11,13 +11,8 @@ In this guide, you will learn:
 - Security measures taken to ensure access is only granted to trusted clients, and specific devices as chosen by the user.
 - The end user flow for external applications integrating with Web Services SmartApps.
 
-.. contents::
-
 Introduction
 ------------
-
-Our goal is to become *the* open platform for the consumer Internet of Things.
-But, that doesn't mean that we can ignore security, even for a minute.
 
 In designing a way to allow external systems API access, we wanted to give developers the flexibility they need, while ensuring that the customer understands why their account is being accessed through an external API, and has specifically authorized that access.
 
@@ -37,8 +32,6 @@ There are a couple of important concepts that need to be understood 
 - When we talk about SmartApps APIs, we are referring to APIs that are exposed by SmartApps themselves.
 - SmartApps execute in a special security context, where they only have access to devices specifically authorized by the user at installation time. This is no different for SmartApps APIs.
 
-.. important:: Right now it is not possible for users outside of the U.S. to install SmartApps using the OAuth install flow. Engineering is actively working to support the OAuth flow outside of the U.S. We will follow up when we have a solution or more information.
-
 How it Works
 ------------
 
@@ -50,7 +43,7 @@ Our overall approach to API access requires the end­ user to authenticate
 
 It is important to understand that it is the SmartApp itself that exposes the API endpoints that are then used by the external system to integration with SmartThings.
 
-This approach is designed to ensure that an external system must have explicit access granted to the devices, before it can control those devices, and that the OAuth access token isn't enough to grant access to the user's entire smart home.
+This approach is designed to ensure that an external system must have explicit access granted to the devices, before it can control those devices.
 
 OAuth-Integrated App Installation Flow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,7 +58,7 @@ the API Connection and Usage process:
 
 #. The external service will typically redirect to the SmartThings login page. The HTTP request to this page includes the required OAuth client id (more details below), allowing our login page to recognize this as a login request using OAuth.
 
-#. The login page is displayed, and if the login is successful, a subsequent page is displayed that allows the non-authenticated user to install and configure the Web Services SmartApp that is associated with the client id. When this step is complete, an authorization code is returned to the browser.
+#. The login page is displayed, and if the login is successful, a subsequent page is displayed that allows the now-authenticated user to install and configure the Web Services SmartApp that is associated with the client id. When this step is complete, an authorization code is returned to the browser.
 
 #. Typically, the authorization code is then given to the external system, and it is used (along with the OAuth client id and client secret), to request an access token. The authorization code takes the place of the user credentials in this case, and is only valid for a single use. Once the external system has the OAuth access token, API requests can be made using this token.
 
@@ -117,29 +110,3 @@ is now complete.
 Once the user authorizes access, the external system is provided with the OAuth authorization code, which is in turn used to request and receive an OAuth access token. Once the external system has the token, it can access the web services provided by the SmartApp.
 
 .. |Alt OAuth-Integrated App Installation| image:: ../img/smartapps/web-services/method-2.png
-
-Rate Limiting
--------------
-
-SmartApps or Device Handler's that expose web services are limited in the number of inbound requests they may receive in a time window. This is to ensure that no one SmartApp or Device Handler consumes too many resources in the SmartThings cloud. There are various headers available on every request that provide information about the current rate limit limits for a given installed SmartApp or Device Handler. These are discussed further below.
-
-SmartApps or Device Handlers that expose web APIs are limited to receiving 250 requests in 60 seconds.
-
-Rate Limit Headers
-~~~~~~~~~~~~~~~~~~
-
-The SmartThings platform will set three HTTP headers on the response for every inbound API call, so that a client may understand the current rate limiting status:
-
-*X-RateLimit-Limit: 250*
-   The rate limit - in this example, the limit is 250 requests.
-
-*X-RateLimit-Current: 1*
-   The current count of requests for the given time window. In this example, there has been one request within the current rate limit time window.
-
-*X-RateLimit-TTL: 58*
-   The time remaining in the current rate limit window. In this example, there is 58 seconds remaining before the current rate limit window resets.
-
-Rate Limit HTTP Status Code
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In addition to the three HTTP headers above, when the rate limit has been exceeded, the HTTP status code of 429 will be sent on the response.

--- a/smartapp-web-services-developers-guide/rate-limiting.rst
+++ b/smartapp-web-services-developers-guide/rate-limiting.rst
@@ -1,0 +1,34 @@
+.. _web_services_rate_limiting:
+
+Rate Limiting
+=============
+
+SmartApps or Device Handler's that expose web services are limited in the number of inbound requests they may receive in a time window.
+This is to ensure that no one SmartApp or Device Handler consumes too many resources in the SmartThings cloud.
+There are various headers available on every request that provide information about the current rate limit limits for a given installed SmartApp or Device Handler.
+These are discussed further below.
+
+SmartApps or Device Handlers that expose web APIs are limited to receiving 250 requests in 60 seconds.
+
+----
+
+Rate Limit Headers
+------------------
+
+The SmartThings platform will set three HTTP headers on the response for every inbound API call, so that a client may understand the current rate limiting status:
+
+*X-RateLimit-Limit: 250*
+   The rate limit - in this example, the limit is 250 requests.
+
+*X-RateLimit-Current: 1*
+   The current count of requests for the given time window. In this example, there has been one request within the current rate limit time window.
+
+*X-RateLimit-TTL: 58*
+   The time remaining in the current rate limit window. In this example, there is 58 seconds remaining before the current rate limit window resets.
+
+----
+
+Rate Limit HTTP Status Code
+---------------------------
+
+In addition to the three HTTP headers above, when the rate limit has been exceeded, the HTTP status code of 429 will be sent on the response.

--- a/smartapp-web-services-developers-guide/smartapp.rst
+++ b/smartapp-web-services-developers-guide/smartapp.rst
@@ -1,0 +1,224 @@
+.. _webservices_smartapp:
+
+The SmartApp
+============
+
+A Web Services SmartApp exposes endpoints that third parties can make REST calls to.
+It can then do anything a normal SmartApp can do - get device status, actuate devices, etc. - and send a response back to the calling client.
+
+----
+
+Enable OAuth
+------------
+
+For a SmartApp to expose endpoints that can receive REST calls from a third party, OAuth must be enabled.
+
+OAuth can be enabled for a SmartApp via the *App Settings* page.
+In the *OAuth* section, check the box to enable OAuth.
+A client ID and secret will be generated for this SmartApp.
+These will be used as part of the OAuth flow to obtain an access token for this SmartApp.
+
+You can also set the Client Display Name and Client Display Link.
+These will be used on the SmartThings Authorization page to inform the user who is requesting access to their devices.
+
+.. image:: ../img/smartapps/web-services/oauth-settings.png
+
+----
+
+Mapping Endpoints
+-----------------
+
+To expose a callable endpoint in your SmartApp, use ``mappings``.
+Specify the various endpoints using ``path``, and specify the supported HTTP methods (``GET``, ``PUT``, ``POST``, and ``DELETE``).
+Each action specified is associated with the name of a method that will handle the request.
+
+.. code-block:: groovy
+
+    mappings {
+        path("/foo") {
+            action: [
+                GET: "getFoo",
+                PUT: "putFoo",
+                POST: "postFoo",
+                DELETE: "deleteFoo"
+            ]
+        }
+        path("/bar") {
+            action: [
+                GET: "getBar"
+            ]
+        }
+    }
+
+    def getFoo() {}
+    def putFoo() {}
+    def postFoo() {}
+    def deleteFoo() {}
+    def getBar() {}
+
+There is no limit to the number of endpoints a SmartApp exposes, but the path level is restricted to four levels deep (i.e., /level1/level2/level3/level4).
+
+You can specify variable URL path parameters using the ``:`` prefix in the path:
+
+.. code-block:: groovy
+
+    mappings {
+        path("/foo/:param1/:param2") {
+            action: [GET: "getFoo"]
+        }
+    }
+
+----
+
+.. _webservices_smartapp_request_handling:
+
+Request Handling
+----------------
+
+When a request is made to one of the SmartApp's endpoints, its associated request handler method will be called.
+
+Every request handler method has available to it a ``request`` object that represents information about the request, and a ``params`` object that contains information about the request parameters.
+
+Path variables
+``````````````
+
+Any path variables you defined in the ``path`` are available via the injected ``params`` object:
+
+.. code-block:: groovy
+
+    mappings {
+        path("/switches/:command") {
+            action: [PUT: "updateSwitches"]
+        }
+    }
+
+    def updateSwitches() {
+        def cmd = params.command
+        log.debug "command: $cmd"
+    }
+
+Query parameters
+````````````````
+
+URL query parameters sent on the request are available via the ``params`` object:
+
+.. code-block:: groovy
+
+    def someHandler() {
+        // this endpoint can accept the "foo" query parameter
+        def fooParam = params.foo
+        log.debug "foo parameter: $foo"
+    }
+
+Request body parameters
+```````````````````````
+
+SmartThings supports JSON or XML request body parameters.
+They can be accessed via ``reqeust.JSON`` and ``request.XML``:
+
+.. code-block:: groovy
+
+    // json on request: '{"foo": "bar"}'
+    def someJSONHandler() {
+        def fooJSON = request.JSON?.foo
+        log.debug "foo json: $fooJSON"
+    }
+
+    // xml on request: '<foo>bar</foo>'
+    def someXMLHandler() {
+        def fooXML = request.XML?.foo
+        log.debug "foo xml: $fooXML"
+    }
+
+.. tip::
+
+    Use the ``?`` (safe navigation operator) to avoid a ``NullPointerException`` if the request JSON or XML is null (in case the request did not send JSON or XML).
+
+The JSON available on the ``request`` will be the result of calling ``new JsonSlurper().parseText()``. You can learn more about working with JSON in Groovy `here <http://www.groovy-lang.org/json.html>`__.
+
+Similarly, the XML on ``request`` is the result of calling ``new XmlSlurper().parseText()``. Learn more about working with XML in Groovy `here <http://www.groovy-lang.org/processing-xml.html>`__.
+
+----
+
+Response Handling
+-----------------
+
+SmartApp endpoints can send response data to the client.
+
+The simplest case is returning a map, which will be serialized to JSON and sent to the client:
+
+.. code-block:: groovy
+
+    def someHandler() {
+        return [foo: "XXXX", bar: "YYYY"]
+    }
+
+The example above would return a ``200`` response with a ``application/json`` response body of:
+
+.. code::
+
+    {
+        "foo":"XXXX",
+        "bar":"YYYY"
+    }
+
+The handler can also use the :ref:`smartapp_render` method for  more fine-grained control over the response:
+
+.. code-block:: groovy
+
+    def someHandler() {
+        def html = """
+    	<!DOCTYPE html>
+        <html>
+            <head><title>Some Title</title></head>
+            <body><p>Testing</p></body>
+        </html>"""
+
+        render contentType: "text/html", data: html
+    }
+
+If not specified, the ``contentType`` will be "application/json", and the ``status`` will be ``200``.
+
+----
+
+Error Handling
+--------------
+
+If your endpoint needs to send an error response, use the :ref:`smartapp_http_error` method:
+
+.. code-block:: groovy
+
+    def someHandler() {
+        def foo = request.JSON?.foo
+
+        if (!foo) {
+            httpError(400, "Foo parameter required")
+        }
+    }
+
+A ``SmartAppException`` will be thrown, and a response will be sent to the client with the specified HTTP code.
+The body of the response will be ``application/json``, and look like this:
+
+.. code::
+
+    {
+        "error":true,
+        "type":"SmartAppException",
+        "message":"your error message"
+    }
+
+
+You should send appropriate error codes and messages for any errors.
+
+For any uncaught exceptions that occur in the SmartApp, a generic ``500`` response will be sent to the client.
+It will look something like this:
+
+.. code::
+
+    {
+        "error": true,
+        "type": "java.lang.NullPointerException",
+        "message": "An unexpected error has occurred."
+    }
+
+The type and message will vary depending upon the specific SmartApp error.

--- a/smartapp-web-services-developers-guide/tutorial-part1.rst
+++ b/smartapp-web-services-developers-guide/tutorial-part1.rst
@@ -10,7 +10,7 @@ In part 1 of this tutorial, you will learn:
 - How to develop a Web Services SmartApp that exposes endpoints.
 - How to call the Web Services SmartApp using simple API calls.
 
-The source code for this tutorial is available `here <https://github.com/SmartThingsCommunity/Code/smartapps/tutorials/web-services-smartapps>`__.
+The source code for this tutorial is available `here <https://github.com/SmartThingsCommunity/Code/tree/master/smartapps/tutorials/web-services-smartapps>`__.
 
 Overview
 --------

--- a/smartapp-web-services-developers-guide/tutorial-part1.rst
+++ b/smartapp-web-services-developers-guide/tutorial-part1.rst
@@ -1,16 +1,16 @@
 .. _smartapp_as_web_service_part_1:
 
-Building a Web Services SmartApp - Part 1
-=========================================
+Web Services Tutorial - SmartApp
+================================
 
-This is the first part of two that will teach you how to build a WebServices SmartApp.
+This is the first part of two that will teach you how to build a Web Services SmartApp and a web application to illustrate the authorization flow.
 
 In part 1 of this tutorial, you will learn:
 
 - How to develop a Web Services SmartApp that exposes endpoints.
 - How to call the Web Services SmartApp using simple API calls.
 
-.. contents::
+The source code for this tutorial is available `here <https://github.com/SmartThingsCommunity/Code/smartapps/tutorials/web-services-smartapps>`__.
 
 Overview
 --------
@@ -31,7 +31,7 @@ Note the Client ID and secret - they'll be used later (should you forget, you ca
 Define Preferences
 ------------------
 
-SmartApps declare preferences metadata that is used at installation and configuration time, to allow the user to control what devices the SmartApp will have access to. 
+SmartApps declare preferences metadata that is used at installation and configuration time, to allow the user to control what devices the SmartApp will have access to.
 
 This is a configuration step, but also a security step, whereby the users must explicitly select what devices the SmartApp can control.
 
@@ -59,18 +59,11 @@ Specify Endpoints
 
 The ``mappings`` declaration allows developers to expose HTTP endpoints, and map the various supported HTTP operations to an associated handler.
 
-The handler can process the HTTP request and provide a response, including both the `HTTP status
-code <https://en.wikipedia.org/wiki/List_of_HTTP_status_codes>`__, as well as the response body.
-
 Our SmartApp will expose two endpoints:
 
-- The ``/switches`` endpoint will support a GET request. A GET request to this endpoint will return state information for the configured switches. 
+- The ``/switches`` endpoint will support a GET request. A GET request to this endpoint will return state information for the configured switches.
 
 - The ``/switches/:command`` endpoint will support a PUT request. A PUT request to this endpoint will execute the specified command (``"on"`` or ``"off"``) on the configured switches.
-
-.. tip::
-  
-  There is no limit to the number of endpoints a SmartApp exposes, but the path level is restricted to four levels deep (i.e., /level1/level2/level3/level4).
 
 Here's the code for our mappings definition. This is defined at the top-level in our SmartApp (i.e., not in another method):
 
@@ -89,22 +82,7 @@ Here's the code for our mappings definition. This is defined at the top-level in
       }
     }
 
-The mappings configuration is made up of one or many ``path`` definitions. Each ``path`` defines the endpoint, and also is configured for each HTTP operation using the ``action`` definition.
-
-``action`` is a simple map, where the key is the HTTP operation (e.g., ``GET``, ``PUT``, ``POST``, etc.), and the value is the name of the handler method to be called when this endpoint is called.
-
 Note the use of variable parameters in our PUT endpoint. Use the ``:`` prefix to specify that the value will be variable. We'll see later how to get this value.
-
-.. tip::
-
-  Endpoints can support multiple REST methods. If we wanted the ``/switches`` endpoint to also support a PUT request, simply add another entry to the ``action`` configuration:
-
-  .. code-block:: groovy
-
-    action: [
-      GET: "listSwitches",
-      PUT: "putHandlerMethodName"
-    ]
 
 Go ahead and add empty methods for the various handlers. We'll fill these in in the next step:
 
@@ -127,7 +105,7 @@ Our handler method returns a list of maps, which is then serialized by the Smart
 
 .. code-block:: groovy
 
-  // returns a list like 
+  // returns a list like
   // [[name: "kitchen lamp", value: "off"], [name: "bathroom", value: "on"]]
   def listSwitches() {
       def resp = []
@@ -159,9 +137,9 @@ If any of the configured switches does not support the specified command, we'll 
             switches.each {
                 if (!it.hasCommand(command)) {
                     httpError(501, "$command is not a valid command for all switches specified")
-                } 
+                }
             }
-            
+
             // all switches have the comand
             // execute the command on all switches
             // (note we can do this on the array - the command will be invoked on every element
@@ -171,14 +149,8 @@ If any of the configured switches does not support the specified command, we'll 
 
 .. tip::
 
-  Our example uses the endpoint itself to get the command. If you would instead like to pass parameters via the request body, you can retrieve those parameters via the built-in ``request`` object as well. Assuming the request body looked like ``{"command": "on"}``, we can get the specified command parameter like this:
-
-  .. code-block:: groovy
-
-    // Get the JSON body from the request.
-    // Safe de-reference using the "?." operator
-    // to avoid NullPointerException if no JSON is passed.
-    def command = request.JSON?.command
+  Our example uses the endpoint itself to get the command.
+  Learn more about working with requests :ref:`here <webservices_smartapp_request_handling>`.
 
 ----
 
@@ -215,23 +187,19 @@ To get information about the switch, we will call the /switch endpoint using a G
 
 .. code-block:: bash
 
-  curl -H "Authorization: Bearer <api token>" <api endpoint>/switch
+  curl -H "Authorization: Bearer <api token>" "<api endpoint>/switches"
 
 This should return a JSON response like the following::
 
   [{"name":"Kitchen 2","value":"off"},{"name":"Living room window","value":"off"}]
 
-To turn the switch on or off, call the /switch endpoint using a PUT request, passing the command in the request body. Again, you'll need to substitute your unique endpoing and API key:
+To turn the switch on or off, call the /switches endpoint using a PUT request. Again, you'll need to substitute your unique endpoing and API key:
 
 .. code-block:: bash
 
-  curl -H "Authorization: Bearer <api token>" -X PUT <api endpoint>/switch/on
+  curl -H "Authorization: Bearer <api token>" -X PUT "<api endpoint>/switches/on"
 
 Change the command value to ``"off"`` to turn the switch off. Try turning the switch on and off, and then using curl to get the status, to see that it changed.
-
-.. tip::
-
-  You can also pass the API token directly on the URL, via the ``access_token`` URL parameter, instead of using the Authorization header. This may be useful when you do not have the ability to set request headers.
 
 ----
 
@@ -248,8 +216,3 @@ Summary
 In this tutorial, you learned how to create a SmartApp that exposes endpoints to get information about, and control, a device. You also learned how to install the SmartApp in the simulator, and then make API calls to the endpoint.
 
 In the next part of this tutorial, we'll look at how a external application might interact with SmartThings using the OAuth2 flow (instead of simply using the simulator and its generated access token).
-
-Source Code
------------
-
-The full source code for this tutorial (both parts), can be found `here <https://github.com/SmartThingsCommunity/Code/tree/master/smartapps/tutorials/web-services-smartapps>`__.

--- a/smartapp-web-services-developers-guide/tutorial-part2.rst
+++ b/smartapp-web-services-developers-guide/tutorial-part2.rst
@@ -13,7 +13,7 @@ In Part 2 of this tutorial, you will learn:
 - How to discover the endpoints of a Web Services SmartApp.
 - How to make calls to the Web Services SmartApp.
 
-The source code for this tutorial is available `here <https://github.com/SmartThingsCommunity/Code/smartapps/tutorials/web-services-smartapps>`__.
+The source code for this tutorial is available `here <https://github.com/SmartThingsCommunity/Code/tree/master/smartapps/tutorials/web-services-smartapps>`__.
 
 Overview
 --------


### PR DESCRIPTION
Goals of this PR:
* Update documentation steps for the OAuth authorization flow to use the `uri` to receive the server-specific SmartApp endpoint.
* Add documentation for the web services SmartApp, including how to expose endpoints, work with the request, response, and errors.
* Update the organization of the web services documentation so that it's easier to navigate and find relevant info.

TODO - add documentation for the removal of the ability to install self-published SmartApps.

Example source code referenced in this documentation is found in this PR: https://github.com/SmartThingsCommunity/Code/pull/13

/cc @tslagle13 @unixbeast 