### PR TITLE
clarify that PUT request handlers return 204 and cannot be changed

### DIFF
--- a/smartapp-web-services-developers-guide/smartapp.rst
+++ b/smartapp-web-services-developers-guide/smartapp.rst
@@ -239,6 +239,7 @@ The example above would return a ``200`` response with a ``application/json`` re
         "bar":"YYYY"
     }
 
+
 The handler can also use the :ref:`smartapp_render` method for  more fine-grained control over the response:
 
 .. code-block:: groovy
@@ -256,6 +257,9 @@ The handler can also use the :ref:`smartapp_render` method for  more fine-graine
 
 If not specified, the ``contentType`` will be "application/json", and the ``status`` will be ``200``.
 
+.. note::
+    ``PUT`` request handlers return a ``204 - No Content`` response, and cannot be overriden.
+    
 ----
 
 Error Handling


### PR DESCRIPTION
A ticket has been created to change this behavior so a request handler can send back a custom response. But until that is done, document the current behavior.