### PR TITLE
add note to clarify Momentary capability

### DIFF
--- a/capabilities-reference.rst
+++ b/capabilities-reference.rst
@@ -999,6 +999,11 @@ None.
 *push()*
     Press the momentary switch
 
+.. note::
+    The Momentary capability does not define any attributes, so subscribing to any events will be Device Handler-specific.
+
+    You should consult the specific Device Handler to see what events may be raised when the ``push()`` command is executed.
+
 **SmartApp Example:**
 
 .. code-block:: groovy


### PR DESCRIPTION
The Momentary capability probably should define its own attribute so that it can become better standardized.

Until then, clarify that it does not have any attributes, so won't have any standard events.