### PR TITLE
adding instructions for installing deps using pip/virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ This documentation is written using [reStructuredText](http://docutils.sourcefor
 
 Follow these steps to build the documentation locally:
 
-1. [Install Sphinx](http://sphinx-doc.org/latest/install.html).
-2. In a terminal, execute `make html` from the root of this repository.
-3. Open `_build/html/index.html` in a web browser.
+1. [Install virtualenv](https://virtualenv.pypa.io/en/latest/installation.html).
+2. Create an isolated environment: `virtualenv --no-site-packages .venv`
+3. Activate the environment: `source .venv/bin/activate`
+4. Install dependencies: `(.venv)~/Documentation$ pip install -r requirements.txt`
+5. Build HTML: `(.venv)~/Documentation$ make html`
+6. Open `_build/html/index.html` in a web browser.
 
 To see the available make targets, simply execute `make`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+Babel==2.2.0
+Jinja2==2.8
+MarkupSafe==0.23
+Pygments==2.1.3
+Sphinx==1.4
+alabaster==0.7.7
+docutils==0.12
+imagesize==0.7.0
+pytz==2016.3
+six==1.10.0
+snowballstemmer==1.2.1
+sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
I followed previous instructions to build the documentation locally, but it doesn't cover installation of dependencies (except Sphinx).

e.g.
```
$ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Traceback (most recent call last):
  File "/usr/bin/sphinx-build", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.6/site-packages/pkg_resources.py", line 2655, in <module>
    working_set.require(__requires__)
  File "/usr/lib/python2.6/site-packages/pkg_resources.py", line 648, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.6/site-packages/pkg_resources.py", line 546, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: docutils>=0.4
make: *** [html] Error 1
```

So I changed instructions to install dependencies using pip and virtualenv.