### PR TITLE
fix build warnings

### DIFF
--- a/getting-started/first-smartapp.rst
+++ b/getting-started/first-smartapp.rst
@@ -673,7 +673,7 @@ Now that you've written your first SmartApp and have a basic understanding of th
 More About SmartApps
 ^^^^^^^^^^^^^^^^^^^^
 
-There is much more you can do with SmartApps than this tutorial covered. SmartApps can :ref:`send notifications <smartapp-sending-notifications>`, :ref:`execute routines <smartapp-routines>`, :ref:`define advanced schedules <smartapp-scheduling>` for which they execute, :ref:`call external web services <calling_web_services>`, and more. You can learn more about developing SmartApps in the :ref:`smartapp_dev_guide` guide.
+There is much more you can do with SmartApps than this tutorial covered. SmartApps can :ref:`send notifications <smartapp_sending_notifications>`, :ref:`execute routines <smartapp-routines>`, :ref:`define advanced schedules <smartapp-scheduling>` for which they execute, :ref:`call external web services <calling_web_services>`, and more. You can learn more about developing SmartApps in the :ref:`smartapp_dev_guide` guide.
 
 You can also make your SmartApp into a web service, capable of exposing its own REST endpoints. You can read about them in the :ref:`smartapp_web_services_guide` guide.
 

--- a/getting-started/groovy-basics.rst
+++ b/getting-started/groovy-basics.rst
@@ -43,7 +43,7 @@ We make heavy use of the Groovy Console to test things out, and recommend you do
 
     For example, ``assert true`` is valid, and the program will continue. Anything that evaluates to false will cause the program to halt, so ``assert false`` will terminate with an informative message.
 
-    While useful for learning, it's important to note that ``assert()`` is **not available** for you to use in SmartThings code. Neither is the method ``println()``, for that matter. For security and performance reasons, SmartThings runs in a sandboxed environment that restricts access to certain features. The sandboxed environment is discussed further in the :ref:`groovy-with-smartthings` tutorial.
+    While useful for learning, it's important to note that ``assert()`` is **not available** for you to use in SmartThings code. Neither is the method ``println()``, for that matter. For security and performance reasons, SmartThings runs in a sandboxed environment that restricts access to certain features. The sandboxed environment is discussed further in the :ref:`groovy-for-smartthings` tutorial.
 
 ----
 

--- a/getting-started/up-and-running.rst
+++ b/getting-started/up-and-running.rst
@@ -68,6 +68,6 @@ Next Steps
 
 Now that you know what the SmartThings developer platform offers, you can dive in to the fun stuff.
 
-If you're new to Groovy, we recommend that you read through the :ref:`groovy-basics` tutorial. You'll learn about Groovy, and how SmartThings uses it for development. The :ref:`groovy-with-smartthings` tutorial discusses some key differences between regular Groovy and Groovy with SmartThings.
+If you're new to Groovy, we recommend that you read through the :ref:`groovy-basics` tutorial. You'll learn about Groovy, and how SmartThings uses it for development. The :ref:`groovy-for-smartthings` tutorial discusses some key differences between regular Groovy and Groovy with SmartThings.
 
 Once you've completed that (or maybe you're the adventurous sort and just want to dive right in to some SmartApp code), check out the :ref:`first-smartapp-tutorial` tutorial.

--- a/sept-2015-faq.rst
+++ b/sept-2015-faq.rst
@@ -11,7 +11,7 @@ September 2015 Release FAQ
 
 **What can developers do with the new Samsung SmartThings Hub and updated mobile apps?**
 
-Developers can use the new Contact Book feature to easily send notifications to a user’s selected contacts, without requesting the user to enter in a phone number for each SmartApp. You can learn more about it in the :ref:`smartapp-sending-notifications` documentation.
+Developers can use the new Contact Book feature to easily send notifications to a user’s selected contacts, without requesting the user to enter in a phone number for each SmartApp. You can learn more about it in the :ref:`smartapp_sending_notifications` documentation.
 
 The new iOS and Android mobile apps also make use of a new Device Tiles layout, that uses a 6 column grid. There is also a new tile available to use for devices - multi-attribute tiles allow a single tile to display information about more than one attribute of a device. You can learn more in the :ref:`device-tiles` documentation.
 


### PR DESCRIPTION
This gets us down to 1 pesky warning about the favicon not existing; it is being picked up, so it's not clear to me yet how to avoid the build warning but still get the favicon.

@unixbeast 

I think we can address these warnings and spend a little time later to see if we can get rid of the one remaining warning. Would be great to get a totally clean build.