### PR TITLE
DOCS-277 - do not allow arbitrary command execution through an endpoint

### DIFF
--- a/smartapp-web-services-developers-guide/smartapp.rst
+++ b/smartapp-web-services-developers-guide/smartapp.rst
@@ -160,6 +160,11 @@ When a request is made to one of the SmartApp's endpoints, its associated reques
 
 Every request handler method has available to it a ``request`` object that represents information about the request, and a ``params`` object that contains information about the request parameters.
 
+.. important::
+
+    All request or path parameters should be validated in your request handler.
+    **Never** allow parameters to arbitrarily execute device commands or otherwise modify data.
+
 Path variables
 ^^^^^^^^^^^^^^
 
@@ -176,6 +181,16 @@ Any path variables you defined in the ``path`` are available via the injected ``
     def updateSwitches() {
         def cmd = params.command
         log.debug "command: $cmd"
+        switch(cmd) {
+            case "on":
+                // handle on command
+                break
+            case "off":
+                // handle off command
+                break
+            default:
+                httpError(501, "$command is not a valid command for all switches specified")
+        }
     }
 
 Query parameters
@@ -190,6 +205,7 @@ URL query parameters sent on the request are available via the ``params`` object
         def fooParam = params.foo
         log.debug "foo parameter: $foo"
     }
+
 
 Request body parameters
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -338,7 +354,7 @@ If not specified, the ``contentType`` will be "application/json", and the ``stat
 Error Handling
 --------------
 
-Default Errors
+Default errors
 ^^^^^^^^^^^^^^
 
 The following errors may be returned by the SmartThings platform:
@@ -354,7 +370,7 @@ HTTP Response Code           Error Message                                      
 ``500 (Server Error)``       {"error":true, "type":"<EXCEPTION-TYPE>", "message": "An unexpected error has occurred"}                        An unhandled exception occurred in the processing of the request. Check the SmartThings live logging to debug.
 ============================ =============================================================================================================== =====
 
-Custom Errors
+Custom errors
 ^^^^^^^^^^^^^
 
 If your endpoint needs to send an error response, use the :ref:`smartapp_http_error` method:

--- a/smartapp-web-services-developers-guide/tutorial-part1.rst
+++ b/smartapp-web-services-developers-guide/tutorial-part1.rst
@@ -139,20 +139,18 @@ If any of the configured switches does not support the specified command, we'll 
         // use the built-in request object to get the command parameter
         def command = params.command
 
-        if (command) {
-
-            // check that the switch supports the specified command
-            // If not, return an error using httpError, providing a HTTP status code.
-            switches.each {
-                if (!it.hasCommand(command)) {
-                    httpError(501, "$command is not a valid command for all switches specified")
-                }
-            }
-
-            // all switches have the comand
-            // execute the command on all switches
-            // (note we can do this on the array - the command will be invoked on every element
-            switches."$command"()
+        // all switches have the comand
+        // execute the command on all switches
+        // (note we can do this on the array - the command will be invoked on every element
+        switch(command) {
+            case "on":
+                switches.on()
+                break
+            case "off":
+                switches.off()
+                break
+            default:
+                httpError(400, "$command is not a valid command for all switches specified")
         }
     }
 

--- a/smartapp-web-services-developers-guide/tutorial-part1.rst
+++ b/smartapp-web-services-developers-guide/tutorial-part1.rst
@@ -139,7 +139,7 @@ If any of the configured switches does not support the specified command, we'll 
         // use the built-in request object to get the command parameter
         def command = params.command
 
-        // all switches have the comand
+        // all switches have the command
         // execute the command on all switches
         // (note we can do this on the array - the command will be invoked on every element
         switch(command) {


### PR DESCRIPTION
I think at some point in the near future some of this needs to be moved to, and expanded on, in a dedicated best practices section or page. For now we want to get this out there soon so it's not leading people down a wrong path, and provides some clarity on not allowing arbitrary command execution through endpoint mappings.

@danlieberman @unixbeast 