### PR TITLE
DOCS-281 - remove logging console from docs

### DIFF
--- a/getting-started/first-smartapp.rst
+++ b/getting-started/first-smartapp.rst
@@ -362,7 +362,7 @@ Now we see the simulator section appear:
 .. image:: ../img/getting-started/first-smartapp/ide-simulator-unactuated.png
    :width: 35%
 
-We have two devices. A motion sensor, and a switch. We can manipulate the motion sensor by choosing "active" or "inactive" and clicking the play button. The same with the switch, it can be "on" or "off". We wrote our SmartApp to turn the switch on when motion is detected, so let's give that a try. Choose "active" if it's not already selected and then hit the play button. You should see some log messages in the console, and the switch should go on:
+We have two devices. A motion sensor, and a switch. We can manipulate the motion sensor by choosing "active" or "inactive" and clicking the play button. The same with the switch, it can be "on" or "off". We wrote our SmartApp to turn the switch on when motion is detected, so let's give that a try. Choose "active" if it's not already selected and then hit the play button. You should see the switch should go on:
 
 .. image:: ../img/getting-started/first-smartapp/ide-simulator-actuated.png
    :width: 35%

--- a/tools-and-ide/editor-and-simulator.rst
+++ b/tools-and-ide/editor-and-simulator.rst
@@ -75,18 +75,3 @@ When simulating a SmartApp, any selected devices will appear in the IDE, along w
 .. note::
 
    Not all of the capabilities we support will work properly in the simulator. We are actively working to close those gaps.
-
-----
-
-Log Console
------------
-
-.. figure:: ../img/ide/console.png
-   :alt: Console
-
-Once installed in the simulator, you will see a log console on the bottom of the page.
-This is where any logging statements in your code will appear.
-
-The most recent logging statements will appear at the top of the logging console.
-
-For more information about logging, refer to the :ref:`logging` chapter of this guide.

--- a/tools-and-ide/logging.rst
+++ b/tools-and-ide/logging.rst
@@ -12,16 +12,8 @@ Overview
 --------
 
 There is an instance of a logger (``log``) injected into each SmartApp/Device Handler available for your use.
-Currently, we do not support a debugger environment for stepping through
-code.
-Logging, however, works to this end in enabling you to log messages to the console in the IDE.
-When you save your code, and start the simulation, a console panel will appear at the bottom of the IDE.
-This is where the log messages from your SmartApp/Device Handler will appear.
-
-.. note::
-    The 'Clear' button will clear all of the messages currently in the console.
-
-.. figure:: ../img/ide/console.png
+SmartThings does not currently support a line-by-line, step-through debugger tool; instead, we use logging to debug our custom code.
+To view the logs, organized by app, click on the *Live Logging* link at the top of the IDE.
 
 ----
 
@@ -95,6 +87,8 @@ It is easy to see that the *debug* message came from the ``updated()`` method
 
     def updated() {
         log.debug "Updated with settings: ${settings}"
+        ...
+    }
 
 But where did the other *trace* messages come from?
 These messages are coming from the SmartApp framework.
@@ -107,15 +101,15 @@ You will also see the *debug* message in the ``someEventHandler()`` method.
 
     log.debug "${onSwitches.size()} out of ${switches.size()} switches are on"
 
-You should expect to see something like this in the console.
+You should expect to see something like this in live logging.
 
 .. note::
-    The newest messages appear at the top of the console output. Not the bottom.
+    The newest messages appear at the top of the live logs, not the bottom.
 
 .. figure:: ../img/ide/log_example2.png
 
 Lets see an example of how each one of the log levels look when output
-to the console.
+to live logging.
 In the ``someEventHandler()`` method, I've added the following log messages for this example.
 
 .. code-block:: groovy


### PR DESCRIPTION
@jodyalbritton this removes references to the logging console from the docs as discussed.