### PR TITLE
Remove "default" from the description

### DIFF
--- a/smartapp-developers-guide/preferences-and-settings.rst
+++ b/smartapp-developers-guide/preferences-and-settings.rst
@@ -577,7 +577,7 @@ Valid options:
 *title*
     String - the title of the label field
 *description*
-    String - the default text in the input field
+    String - the text in the input field
 *required*
     Boolean - ``true`` or ``false`` to specify this input is required. Defaults to ``false``. Defaults to ``true``.
 *image*


### PR DESCRIPTION
The word "default" in the description description can cause confusion leading the developer believe that it works similar to defaultValue which (in hind sight) is not the case.