### PR TITLE
formatting fixes/suggestions for cli docs

### DIFF
--- a/tools-and-ide/cli.rst
+++ b/tools-and-ide/cli.rst
@@ -2,8 +2,18 @@
 Command Line Tool
 =================
 
+SmartThings offers a Command Line Interface (CLI) for working with SmartThings artifacts using the tools, source code control, and editor of their choice.
+With the CLI, developers can:
+
+- Create new SmartApps and Device Handlers
+- Save SmartApps and Device Handlers to SmartThings
+- Self-publish SmartApps and Device Handlers to SmartThings
+
+----
+
 What is a CLI?
 --------------
+
 A CLI (command line interface) is a user interface to a computer's operating
 system or an application in which the user responds to a visual prompt by typing
 in a command on a specified line, receives a response back from the system, and
@@ -26,17 +36,16 @@ interface with the SmartThings platform.
 Prerequisites
 -------------
 
-The CLI tool requires that you have a command prompt that is accessable on your
+The CLI tool requires that you have a command prompt that is accessible on your
 computer. This means you must have an application like *Terminal* on **OS (X)**
 and **Linux** or the command prompt, *CMD* on **Windows**.
 
 Supported Operating Systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-**Mac OS (X) (Beta)**
 
-**Windows (Beta)**
-
-**Linux (Alpha)**
+- Mac OS (X) (Beta)
+- Windows (Beta)
+- Linux (Alpha)
 
 .. note::
 
@@ -51,47 +60,37 @@ Supported Operating Systems
 Installation
 ------------
 
-Download
-^^^^^^^^
+Download and install
+^^^^^^^^^^^^^^^^^^^^
 
-Download the binary for your OS
+**Windows:**
 
-**Windows**
-`SmartThings Windows CLI <https://cdn-cli.smartthings.com/releases/latest/windows/stdev.exe>`_
+#. Download the `SmartThings Windows CLI <https://cdn-cli.smartthings.com/releases/latest/windows/stdev.exe>`_
+#. Place the .exe file in your path (`tutorial <http://www.howtogeek.com/118594/how-to-edit-your-system-path-for-easy-command-line-access/>`_)
 
-Place the .exe file in your path (`tutorial <http://www.howtogeek.com/118594/how-to-edit-your-system-path-for-easy-command-line-access/>`_)
+**OS X:**
 
-**OS X**
-`SmartThings Windows CLI <https://cdn-cli.smartthings.com/releases/latest/osx/stdev>`_
-
-Install
-^^^^^^^
-
-Place the downloaded binary in a safe place, and add it to your system path. This
-will make it available in all your terminal sessions.
-
-Run the following command on the executable:
-``chmod u+rwx stdev``
+#. Download the `SmartThings OSX CLI <https://cdn-cli.smartthings.com/releases/latest/osx/stdev>`_
+#. Place the downloaded binary in a safe place, and add it to your system path. This will make it available in all your terminal sessions.
+#. Run the following command on the executable: ``chmod u+rwx stdev``
 
 .. note::
 
-    OS X security may remove execute privileges and quarantine file.  To fix:
+    OS X security may remove execute privileges and quarantine file.
+    To fix this, execute the following commands:
     ``xattr -d com.apple.quarantine stdev``
     ``chmod u+rwx stdev``
 
-**Linux**
-`SmartThings Windows CLI <https://cdn-cli.smartthings.com/releases/latest/linux/stdev>`_
+**Linux:**
 
-Place the downloaded binary in a safe place, and add it to your system path. This
-will make it available in all your terminal sessions.
+#. Download the `SmartThings Linux CLI <https://cdn-cli.smartthings.com/releases/latest/linux/stdev>`_
+#. Place the downloaded binary in a safe place, and add it to your system path. This will make it available in all your terminal sessions.
+#. Run the following command on the executable: ``chmod u+rwx stdev``
 
-Run the following command on the executable:
-``chmod u+rwx stdev``
-
-Verify Installation
+Verify installation
 ^^^^^^^^^^^^^^^^^^^
 
-Executing the following command should produce the output observed below:
+Executing the following command should produce the output observed below.
 
 .. code-block:: shell
 
@@ -161,6 +160,107 @@ what is currently configured, use the command ``stdev info``.
 ^^^^^^^^^
 You can place a ``.stignore`` file in any project src directory. The ``.stignore``
 file works exactly the same as a `.gitignore <https://git-scm.com/docs/gitignore>`_ file.
+
+----
+
+Common Scenarios
+----------------
+
+Create a new project
+^^^^^^^^^^^^^^^^^^^^
+
+A common scenario is creating a new SmartApp. Let's see how we can do this with
+the CLI tool.
+
+.. code-block:: bash
+
+    stdev generate ./turnon
+
+This command will walk us through a couple of questions and then create a new
+project for us in the directory specified on the command line.
+In the example above, a new directory named *turnon* will be created in our current working directory.
+
+The CLI tool will create the SmartThings recommended directory structure for our
+project. It looks like this:
+
+.. code-block:: bash
+
+    ./turnon
+    |
+    + - /devicetypes
+    |
+    + - /smartapps
+        |
+        + - <namespace>
+            |
+            + - turnon.src
+                |
+                + - turnon.groovy
+
+Save project
+^^^^^^^^^^^^
+
+Use the :ref:`save` command to save a project to SmartThings.
+This will push your changes to the SmartThings IDE.
+
+Let's paste come code into the turnon.groovy file:
+
+.. code-block:: groovy
+
+    preferences {
+        section("When the door opens..."){
+            input "contact1", "capability.contactSensor", title: "Where?"
+        }
+        section("Turn on a light..."){
+            input "switches", "capability.switch", multiple: true
+        }
+    }
+
+
+    def installed() {
+        subscribe(contact1, "contact.open", contactOpenHandler)
+    }
+
+    def updated() {
+        unsubscribe()
+        subscribe(contact1, "contact.open", contactOpenHandler)
+    }
+
+    def contactOpenHandler(evt) {
+        log.debug "$evt.value: $evt, $settings"
+        log.trace "Turning on switches: $switches"
+        switches.on()
+    }
+
+The ``save`` command requires the path to the directory you wish to save.
+
+.. code-block:: bash
+
+    stdev save ./smartapps/<namespace>/turnon.src
+
+You should receive a success message:
+
+.. code-block:: bash
+
+    Executable successfully saved [id: 12345678-1234-1234-1234-123456789101]
+
+You should now be able to browse to the `SmartThings Web IDE <https://graph.api.smartthings.com>`_
+and see your new SmartApp in your SmartApp list.
+
+Publish a project
+^^^^^^^^^^^^^^^^^
+
+The last step is to publish our project so we can install it in the mobile app:
+
+.. code-block:: bash
+
+    stdev publish ./smartapps/<namespace>/turnon.src
+
+Again, you should receive a success message:
+
+.. code-block:: bash
+
+    Executable successfully published [smartapps/<namespace>/turnon.src]
 
 ----
 
@@ -300,111 +400,16 @@ info
 
 ----
 
-Common Scenarios
-----------------
-
-Create a new project
-^^^^^^^^^^^^^^^^^^^^
-
-A common scenario is creating a new SmartApp. Let's see how we can do this with
-the CLI tool.
-
-.. code-block:: bash
-
-    stdev generate ./turnon
-
-This command will walk us through a couple of questions and then create a new
-project for us in the directory specified on the command line. In the example
-above, a new directory named *turnon* will be created in our current working
-directory.
-
-The CLI tool will create the SmartThings recommended directory structure for our
-project. It looks like this:
-
-.. code-block:: bash
-
-    ./turnon
-    |
-    + - /devicetypes
-    |
-    + - /smartapps
-        |
-        + - <namespace>
-            |
-            + - turnon.src
-                |
-                + - turnon.groovy
-
-
-Let's paste come code into the turnon.groovy file:
-
-.. code-block:: groovy
-
-    preferences {
-        section("When the door opens..."){
-            input "contact1", "capability.contactSensor", title: "Where?"
-        }
-        section("Turn on a light..."){
-            input "switches", "capability.switch", multiple: true
-        }
-    }
-
-
-    def installed() {
-        subscribe(contact1, "contact.open", contactOpenHandler)
-    }
-
-    def updated() {
-        unsubscribe()
-        subscribe(contact1, "contact.open", contactOpenHandler)
-    }
-
-    def contactOpenHandler(evt) {
-        log.debug "$evt.value: $evt, $settings"
-        log.trace "Turning on switches: $switches"
-        switches.on()
-    }
-
-The next step is to save this new SmartApp in our SmartThings account. Recall that
-the save command requires a path to a src directory.
-
-.. code-block:: bash
-
-    stdev save ./smartapps/<namespace>/turnon.src
-
-You should receive a success message:
-
-.. code-block:: bash
-
-    Executable successfully saved [id: 12345678-1234-1234-1234-123456789101]
-
-You should now be able to browse to the `SmartThings Web IDE <https://graph.api.smartthings.com>`_
-and see your new SmartApp in your SmartApp list.
-
-The last step is to publish our SmartApp so we can install it in the mobile app.
-
-.. code-block:: bash
-
-    stdev publish ./smartapps/<namespace>/turnon.src
-
-Again, you should receive a success message:
-
-.. code-block:: bash
-
-    Executable successfully published [smartapps/<namespace>/turnon.src]
-
-----
-
 FAQ
 ---
 
-**Can I download existing SmartApps from the Wed IDE with the CLI?**
+**Question: Can I download existing SmartApps from the Wed IDE with the CLI?**
 
-**Answer:** This is currently not possible. However, you can keep your code synced 
-in the cloud with the use of a SCM tool like git.
+*Answer: This is currently not possible. However, you can keep your code synced
+in the cloud with the use of a SCM tool like git.*
 
-**Will the CLI ever have command completion?**
+**Question: Will the CLI ever have command completion?**
 
-**Answer:** Command completion is coming soon!
+*Answer: Command completion is coming soon!*
 
 ----


### PR DESCRIPTION
This is still a WIP but this PR contains a few formatting changes:

* Add introductory text to clearly state what the CLI can do for developers
* Streamline download and install instructions by OS
* Move scenarios above commands
* Breakout create, save, publish into separate sub-topics

@unixbeast 