### PR TITLE
[DOCS-304] added documentation around using collections in state

### DIFF
--- a/code-review-guidelines.rst
+++ b/code-review-guidelines.rst
@@ -304,6 +304,12 @@ Understand when to use ``atomicState`` vs. ``state``
 
 Understand the :ref:`difference <atomic_state>` between ``atomicState`` and ``state``, make sure you use the correct one for your needs, and avoid using both in the same SmartApp.
 
+Take care when storing collections in ``atomicState``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Modifying collections in Atomic State does not work as it does with State.
+:ref:`Read the documentation <state_using_collections>` to understand how to best work with collections stored in Atomic State.
+
 ----
 
 Web Services

--- a/smartapp-developers-guide/state.rst
+++ b/smartapp-developers-guide/state.rst
@@ -15,7 +15,6 @@ Recall that SmartApps (and Device Handlers) are not always running, but rather e
 Here's a quick example showing how to work with state:
 
 .. code-block:: groovy
-    :linenos:
 
     state.myData = "some data"
     log.debug "state.myData = ${state.myData}"
@@ -47,7 +46,6 @@ The contents of ``state`` are stored as a JSON string. This means that anything 
   This is particularly worth noting when working with dates. If you need to store time information, consider using an epoch time stamp, conveniently available via the ``now()`` method:
 
   .. code-block:: groovy
-    :linenos:
 
     def installed() {
       state.installedAt = now()
@@ -72,7 +70,6 @@ To use ``state``, simply use the ``state`` variable that is injected into every 
 As usual, the best way to describe code is by showing code itself.
 
 .. code-block:: groovy
-    :linenos:
 
     def installed() {
         // simple number to keep track of executions
@@ -186,6 +183,49 @@ When the character limit has been exceeded, a ``physicalgraph.exception.StateCha
     If using ``atomicState``, which reads and writes to the external data store when the object is updated or accessed, you will be able to handle a ``StateCharacterLimitExceededException`` in your code.
 
     Additional helper methods to get the remaining available size and the character limit will be added in a future release.
+
+----
+
+.. _state_using_collections:
+
+Using Collections in State
+--------------------------
+
+When storing collections in State, things are pretty straightforward.
+Simply assign the collection to ``state``, and update entries as needed:
+
+.. code-block:: groovy
+
+    def initialize() {
+        state.myMap = ["key1": "val1"]
+        log.debug "state: $state"
+        state.myMap.key1 = "UPDATED"
+        log.debug "state: $state" // state is now [key1: UPDATED]
+    }
+
+Updating collections stored in Atomic State is a little trickier - following the same pattern as above **will not work**.
+Instead, you will need to assign the collection to a local variable, make changes as needed, then assign it back to ``atomicState``.
+Here's an example:
+
+.. code-block:: groovy
+
+    def initialize() {
+        atomicState.myMap = [key1: "val1"]
+        log.debug "atomicState: $atomicState"
+
+        // assign collection to local variable and update
+        def temp = atomicState.myMap
+        // update existing entry
+        temp.key1 = "UPDATED"
+        // add new entry
+        temp.key2 = "val2"
+
+        // assign collection back to atomicState
+        atomicState.myMap = temp
+        log.debug "atomicState: $atomicState"
+    }
+
+This applies to all collection operations on items stored in Atomic State (adding, removing, modifying, etc).
 
 ----
 


### PR DESCRIPTION
Using collections in atomicState has caused confusion for developers when trying to modify the collection (adding, changing, or removing elements). The behavior is different between `state` and `atomicState`, creating more confusion.

This PR attempts to document the differences and a recommended way of working with collections in `atomicState`. 

I do not know if this behavior is intentional, a bug, or an unintended consequence of the implementation of `atomicState`. This PR simply documents how things behave right now.

@rappleg or @Bijnagte I'd like you to review/confirm this, or delegate to someone who can review.

/cc @dsainteclaire 