### PR TITLE
[DOCS-319] remove sept 2015 release faq from top nav

### DIFF
--- a/docs-change-log.rst
+++ b/docs-change-log.rst
@@ -15,7 +15,7 @@ A log of changes to this documentation.
 
 ----
 
-25 July 2016
+July 25 2016
 ------------
 
 `GitHub Release Tag <https://github.com/SmartThingsCommunity/Documentation/releases/tag/25-July-2016>`__
@@ -24,7 +24,7 @@ A log of changes to this documentation.
 
 ----
 
-21 July 2016
+July 21 2016
 ------------
 
 `GitHub Release Tag <https://github.com/SmartThingsCommunity/Documentation/releases/tag/21-July-2016>`__
@@ -33,7 +33,7 @@ A log of changes to this documentation.
 
 ----
 
-07 July 2016
+July 07 2016
 ------------
 
 `GitHub Release Tag <https://github.com/SmartThingsCommunity/Documentation/releases/tag/07-July-2016>`__
@@ -46,7 +46,7 @@ A log of changes to this documentation.
 
 ----
 
-23 June 2016
+June 23 2016
 ------------
 
 `GitHub Release Tag <https://github.com/SmartThingsCommunity/Documentation/releases/tag/23-June-2016>`__
@@ -58,7 +58,7 @@ A log of changes to this documentation.
 
 ----
 
-17 June 2016
+June 17 2016
 ------------
 
 `GitHub Release Tag <https://github.com/SmartThingsCommunity/Documentation/releases/tag/17-June-2016>`__
@@ -67,7 +67,7 @@ A log of changes to this documentation.
 
 ----
 
-13 June 2016
+June 13 2016
 ------------
 
 `GitHub Release Tag <https://github.com/SmartThingsCommunity/Documentation/releases/tag/13-June-2016>`__
@@ -76,7 +76,7 @@ A log of changes to this documentation.
 
 ----
 
-9 June 2016
+June 9 2016
 -----------
 
 `GitHub Release Tag <https://github.com/SmartThingsCommunity/Documentation/releases/tag/09-June-2016>`__
@@ -90,14 +90,14 @@ A log of changes to this documentation.
 
 ----
 
-27 May 2016
+May 27 2016
 -----------
 
 - Add ``additionalParams`` argument for ZigBee library. :doc:`Docs <ref-docs/zigbee-ref>` | `GitHub PR <https://github.com/SmartThingsCommunity/Documentation/pull/315>`__
 
 ----
 
-23 May 2016
+May 23 2016
 -----------
 
 - Updated and expanded Device Handler tiles docs. :doc:`Docs <device-type-developers-guide/tiles-metadata>`  | `GitHub PR <https://github.com/SmartThingsCommunity/Documentation/pull/314>`__.

--- a/index.rst
+++ b/index.rst
@@ -29,9 +29,9 @@ Contents
 --------
 
 .. toctree::
-    :maxdepth: 1
+   :maxdepth: 1
 
-    sept-2015-faq
+   docs-change-log
 
 .. toctree::
    :caption: Getting Started
@@ -57,7 +57,7 @@ Contents
    arduino/index
    code-review-guidelines
    contributing/index
-   docs-change-log
+   sept-2015-faq
 
 .. toctree::
     :maxdepth: 1

--- a/sept-2015-faq.rst
+++ b/sept-2015-faq.rst
@@ -1,6 +1,6 @@
-==========================
-September 2015 Release FAQ
-==========================
+===========================
+Sumsung SmartThings Hub FAQ
+===========================
 
 *A collection of frequently asked questions about the new Samsung SmartThings Hub, and updated SmartThings mobile applications, for SmartThings developers.*
 


### PR DESCRIPTION
Also moves the docs change log up to the top of the nav tree.

/cc @tslagle13 