### PR TITLE
[DOCS-254] - add links in the Device Handler guide to other available APIs

### DIFF
--- a/device-type-developers-guide/index.rst
+++ b/device-type-developers-guide/index.rst
@@ -34,5 +34,6 @@ Table of Contents:
    zigbee-primer
    building-zigbee-device-handlers
    zigbee-example
+   other-available-apis
    submitting-device-types-for-publication
    device-integration

--- a/device-type-developers-guide/other-available-apis.rst
+++ b/device-type-developers-guide/other-available-apis.rst
@@ -1,0 +1,34 @@
+====================
+Other Useful Methods
+====================
+
+Device Handlers have available to them other APIs for features like scheduling, storing data, and making HTTP requests.
+While not often necessary for Device Handlers, these features can be useful for certain use cases.
+
+----
+
+Scheduling
+----------
+
+Device Handlers can schedule future executions, just like SmartApps, with one notable difference - the ``runEvery*()`` methods are **not available**.
+
+You can learn about scheduling in the :ref:`smartapp-scheduling` guide.
+
+----
+
+Storing Data
+------------
+
+Device Handlers can persist small amounts of data across exections using ``state``, just as SmartApps.
+Note that Atomic State is **not available** to Device Handlers.
+
+You can learn about storing data in the :ref:`storing-data` guide.
+
+----
+
+Making External HTTP Requests
+-----------------------------
+
+Device Handlers can make HTTP requests to third party services, just like SmartApps.
+
+You can learn about making HTTP requests in the :ref:`calling_web_services` guide.

--- a/smartapp-developers-guide/calling-web-services-in-smartapps.rst
+++ b/smartapp-developers-guide/calling-web-services-in-smartapps.rst
@@ -1,7 +1,7 @@
 .. _calling_web_services:
 
-Calling Web Services
-====================
+Making External HTTP Requests
+=============================
 
 SmartApps or Device Handlers may need to make calls to external web services. There are several APIs available to you to handle making these requests.
 

--- a/smartapp-developers-guide/state.rst
+++ b/smartapp-developers-guide/state.rst
@@ -1,7 +1,7 @@
 .. _storing-data:
 
-Storing Data
-============
+State - Storing Data
+====================
 
 SmartApps and Device Handlers are all provided a ``state`` variable that will allow you to store data across executions.
 


### PR DESCRIPTION
Device Handlers can call scheduling, state, and http APIs (for the most part, with exceptions noted in the changes in this PR). Our current docs organization makes discovering these APIs within Device Handler development less than optimal. Rather than duplicate the content within the DH guide, or not do anything until the entire organization/information hierarchy is redone, I just created a new page with links to topics in the SmartApp guide.

I also changed a couple titles of docs to make them more clear/discoverable.