### PR TITLE
CREX-5898 - Document how to send data to a scheduled handler.

### DIFF
--- a/smartapp-developers-guide/scheduling.rst
+++ b/smartapp-developers-guide/scheduling.rst
@@ -279,6 +279,37 @@ Using them is similar to other scheduling methods:
 
 ----
 
+Passing Data to the Handler Method
+--------------------------------------
+
+Sometimes it is useful to pass data to the handler method. This is possible by passing in a map as the last
+argument to the various schedule methods with ``data`` as the key and another map as the value.
+
+.. code-block:: groovy
+    :emphasize-lines: 2
+
+    def someEventHandler(evt) {
+        runIn(60, handler, [data: [flag: true]])
+    }
+
+    def handler(data) {
+        if (data.flag) {
+            theswitch.off()
+        }
+    }
+
+By passing data directly to the handler method, you can avoid having to store data in the SmartApp or Device Handler state. Data can be passed
+in this fashion to any of the schedule methods: ``runIn()``, ``runOnce()``, ``schedule()``, ``runEveryXMinutes()``, and ``runEveryXHours()``.
+
+To also specify the overwrite flag, pass it as an additional property in the map: ``[overwrite: false, data: [foo: 'bar']]``.
+
+.. note::
+
+    Similar to the state, only data that can be serialized can be passed to the handler. The data is also limited to 2500 characters after being serialized.
+    If the size exceeds the maximum number of characters, an exception of type ``physicalgraph.exception.DataCharacterLimitExceededException`` will be thrown.
+
+----
+
 Removing Scheduled Executions
 -----------------------------
 


### PR DESCRIPTION
CC @charliek @bflorian @jimmyjames @rappleg 

Documenting how to send data to a scheduled handler method. This is a good feature, which could help prevent people from abusing the state. Note: this only works with the cloud scheduler, and not the local one.

![screen shot 2016-08-25 at 11 18 57 am](https://cloud.githubusercontent.com/assets/1022924/17977285/b38df506-6ab6-11e6-83a6-ef5ef1943796.png)
