### PR TITLE
correct missing brace in httpget example 

### DIFF
--- a/ref-docs/smartapp-ref.rst
+++ b/ref-docs/smartapp-ref.rst
@@ -627,6 +627,7 @@ If the response content type is JSON, the response data will automatically be pa
         }
         log.debug "response contentType: ${resp.contentType}"
         log.debug "response data: ${resp.data}"
+        }
     } catch (e) {
         log.error "something went wrong: $e"
     }


### PR DESCRIPTION
I wanted to resolve #386  that I submitted just a few minutes ago. 
It's a trivial fix that I've checked in the simulator.