### PR TITLE
correcting color-control capability

### DIFF
--- a/capabilities-reference.rst
+++ b/capabilities-reference.rst
@@ -639,9 +639,6 @@ key           value
 ============= ===============================
 hue           ``0-100 (percent)``
 saturation    ``0-100 (percent)``
-hex           ``"#000000" - "#FFFFFF" (Hex)``
-level         ``0-100 (percent)``
-switch        ``"on"`` or ``"off"``
 ============= ===============================
 
 **Commands:**


### PR DESCRIPTION
Taking out hex, switch, and level from the supported color map options. These are not inherently supported by the capability, however, some device handlers may implement support for these values.