### PR TITLE
typo: device types: ZibBee -> ZigBee

### DIFF
--- a/device-type-developers-guide/overview.rst
+++ b/device-type-developers-guide/overview.rst
@@ -143,7 +143,7 @@ Protocols
 SmartThings currently supports both the `Z-Wave <http://en.wikipedia.org/wiki/Z-Wave>`__ and `ZigBee <http://en.wikipedia.org/wiki/ZigBee>`__ wireless protocols.
 
 Since the device handler is responsible for communicating between the device and the SmartThings platform, it is usually necessary to understand and communicate in whatever protocol the device supports.
-This guide will discuss both Z-Wave and ZibBee protocols at a high level.
+This guide will discuss both Z-Wave and ZigBee protocols at a high level.
 
 ----
 

--- a/device-type-developers-guide/parse.rst
+++ b/device-type-developers-guide/parse.rst
@@ -12,7 +12,7 @@ All messages from the device are passed to the ``parse()`` method.
 It is responsible for turning those messages into something the SmartThings platform can understand.
 
 Because the ``parse()`` method is responsible for handling raw device messages, their implementations vary greatly across different device types.
-This document will not discuss all these different scenarios (see the `Z-Wave Device Handler Guide <building-z-wave-device-handlers.html>`__ or `ZibBee Device Handler guide <building-zigbee-device-handlers.html>`__ for protocol-specific information).
+This document will not discuss all these different scenarios (see the `Z-Wave Device Handler Guide <building-z-wave-device-handlers.html>`__ or `ZigBee Device Handler guide <building-zigbee-device-handlers.html>`__ for protocol-specific information).
 
 Consider an example of a simplified ``parse()`` method (modified from the CentraLite Switch):
 

--- a/device-type-developers-guide/zigbee-example.rst
+++ b/device-type-developers-guide/zigbee-example.rst
@@ -1,7 +1,7 @@
 ZigBee Example
 ==============
 
-An example of a ZibBee device-type is a ZigBee dimmer.
+An example of a ZigBee device-type is a ZigBee dimmer.
 
 Here is the code.
 


### PR DESCRIPTION
This commit fixes a few references to "ZibBee" which is not
a thing.  ZigBee is, however, and clearly the intent of the
author.