### PR TITLE
[DOCS-344] - refactor reference API docs to use getter style

### DIFF
--- a/ref-docs/app-state-ref.rst
+++ b/ref-docs/app-state-ref.rst
@@ -20,20 +20,20 @@ Here is a small code snippet that illustrates a potential use case.
 
 ----
 
-dateValue
----------
+getDateValue()
+--------------
 
 The value of this Event, if the value can be parsed to a Date.
 
 **Signature:**
-    ``Date dateValue``
+    ``Date getDateValue()``
 
 **Returns:**
     `Date`_ - the value of this Event as a Date.
 
 .. warning::
 
-    ``dateValue`` will throw an Exception if the value of the event is not parseable to a Date.
+    ``getDateValue()`` will throw an Exception if the value of the event is not parseable to a Date.
 
     You should wrap calls in a try/catch block.
 
@@ -55,13 +55,13 @@ The value of this Event, if the value can be parsed to a Date.
 
 ----
 
-id
---
+getId()
+-------
 
 The unique system identifier for this event.
 
 **Signature:**
-    ``String id``
+    ``String getId()``
 
 **Returns:**
     `String`_ - the unique device identifier for this event.
@@ -77,13 +77,13 @@ The unique system identifier for this event.
 
 ----
 
-descriptionText
----------------
+getDescriptionText()
+--------------------
 
 The description of the event that is to be displayed to the user in the mobile application.
 
 **Signature:**
-    ``String descriptionText``
+    ``String getDescriptionText()``
 
 **Returns:**
     `String`_ - the description of this event to be displayed to the user in the mobile application.
@@ -99,20 +99,20 @@ The description of the event that is to be displayed to the user in the mobile a
 
 ----
 
-doubleValue
------------
+getDoubleValue()
+----------------
 
 The value of this Event, if the value can be parsed to a Double.
 
 **Signature:**
-    ``Double doubleValue``
+    ``Double getDoubleValue()``
 
 **Returns:**
     `Double`_ - the value of this Event as a Double.
 
 .. warning::
 
-    ``doubleValue`` will throw an Exception if the value of the event is not parseable to a Double.
+    ``getDoubleValue()`` will throw an Exception if the value of the event is not parseable to a Double.
 
     You should wrap calls in a try/catch block.
 
@@ -134,20 +134,20 @@ The value of this Event, if the value can be parsed to a Double.
 
 ----
 
-floatValue
-----------
+getFloatValue()
+---------------
 
 The value of this Event as a Float, if it can be parsed into a Float.
 
 **Signature:**
-    ``Float foatValue``
+    ``Float getFoatValue()``
 
 **Returns:**
     `Float`_ - the value of this Event as a Float.
 
 .. warning::
 
-    ``floatValue`` will throw an Exception if the Event's value is not parseable to a Float.
+    ``getFloatValue()`` will throw an Exception if the Event's value is not parseable to a Float.
 
     You should wrap calls in a try/catch block.
 
@@ -169,20 +169,20 @@ The value of this Event as a Float, if it can be parsed into a Float.
 
 ----
 
-integerValue
-------------
+getIntegerValue()
+-----------------
 
 The value of this Event as an Integer.
 
 **Signature:**
-    ``Integer integerValue``
+    ``Integer getIntegerValue()``
 
 **Returns:**
     `Integer`_ - the value of this Event as an Integer.
 
 .. warning::
 
-    ``integerValue`` throws an Exception of the Event value cannot be parsed to an Integer.
+    ``getIntegerValue()`` throws an Exception of the Event value cannot be parsed to an Integer.
 
     You should wrap calls in a try/catch block.
 
@@ -204,13 +204,13 @@ The value of this Event as an Integer.
 
 ----
 
-isoDate
--------
+getIsoDate()
+------------
 
 Acquisition time of this Event as an ISO-8601 String.
 
 **Signature:**
-    ``String isoDate``
+    ``String getIsoDate()``
 
 **Returns:**
     `String`_ - The acquisition time of this Event as an ISO-8601 String.
@@ -226,20 +226,20 @@ Acquisition time of this Event as an ISO-8601 String.
 
 ----
 
-jsonValue
----------
+getJsonValue()
+--------------
 
 Value of the Event as a parsed JSON data structure.
 
 **Signature:**
-    ``Object jsonValue``
+    ``Object getJsonValue()``
 
 **Returns:**
     `Object`_ - The value of the Event as a JSON structure
 
 .. warning::
 
-    ``jsonValue`` throws an Exception if the value of the Event cannot be parsed into a JSON object.
+    ``getJsonValue()`` throws an Exception if the value of the Event cannot be parsed into a JSON object.
 
     You should wrap calls in a try/catch block.
 
@@ -260,13 +260,13 @@ Value of the Event as a parsed JSON data structure.
 
 ----
 
-lastUpdated
------------
+getLastUpdated()
+----------------
 
 The last time this event was updated as a Date.
 
 **Signature:**
-    ``Date lastUpdated``
+    ``Date getLastUpdated()``
 
 **Returns:**
     `Date`_ - The last time this event was updated as a Date.
@@ -282,20 +282,20 @@ The last time this event was updated as a Date.
 
 ----
 
-longValue
----------
+getLongValue()
+--------------
 
 The value of this Event as a Long.
 
 **Signature:**
-    ``Long longValue``
+    ``Long getLongValue()``
 
 **Returns:**
     `Long`_ - the value of this Event as a Long.
 
 .. warning::
 
-    ``longValue`` throws an Exception if the value of the Event cannot be parsed to a Long.
+    ``getLongValue()`` throws an Exception if the value of the Event cannot be parsed to a Long.
 
     You should wrap calls in a try/catch block.
 
@@ -308,7 +308,7 @@ The value of this Event as a Long.
         // get the value of this event as an Long
         // throws an exception if not convertable to Long
         try {
-            def evtLongValue = myState.longVaue
+            def evtLongValue = myState.longValue
             log.debug "The longValue of this event is $evtLongValue"
             log.debug "evt.longValue instanceof Long? ${evtLongValue instanceof Long}"
         } catch (e) {
@@ -318,13 +318,13 @@ The value of this Event as a Long.
 
 ----
 
-name
-----
+getName()
+---------
 
 The name of this Event.
 
 **Signature:**
-    ``String name``
+    ``String getName()``
 
 **Returns:**
     `String`_ - the name of this event.
@@ -340,20 +340,20 @@ The name of this Event.
 
 ----
 
-numberValue
------------
+getNumberValue()
+----------------
 
 The value of this Event as a Number.
 
 **Signature:**
-    ``BigDecimal numberValue``
+    ``Number getNumberValue()``
 
 **Returns:**
-    `BigDecimal`_ - the value of this event as a BigDecimal.
+    `Number`_ - the value of this event as a BigDecimal.
 
 .. warning::
 
-    ``numberValue`` throws an Exception if the value of the Event cannot be parsed to a BigDecimal.
+    ``getNumberValue()`` throws an Exception if the value of the Event cannot be parsed to a Number.
 
     You should wrap calls in a try/catch block.
 
@@ -368,7 +368,7 @@ The value of this Event as a Number.
         try {
             def evtNumberValue = myState.numberValue
             log.debug "The numberValue of this event is ${evtNumberValue}"
-            log.debug "evt.numberValue instanceof BigDecimal? ${evtNumberValue instanceof BigDecimal}"
+            log.debug "evt.numberValue instanceof BigDecimal? ${evtNumberValue instanceof Number}"
         } catch (e) {
             log.debug("Trying to get the numberValue for ${myState.name} threw an exception", e)
         }
@@ -376,20 +376,20 @@ The value of this Event as a Number.
 
 ----
 
-numericValue
-------------
+getNumericValue()
+-----------------
 
 The value of this Event as a Number.
 
 **Signature:**
-    ``BigDecimal numericValue``
+    ``Number getNumericValue()``
 
 **Returns:**
-    `BigDecimal`_ - the value of this event as a BigDecimal.
+    `Number`_ - the value of this event as a BigDecimal.
 
 .. warning::
 
-    ``numericValue`` throws an Exception if the value of the Event cannot be parsed to a BigDecimal.
+    ``getNumericValue()`` throws an Exception if the value of the Event cannot be parsed to a Number.
 
     You should wrap calls in a try/catch block.
 
@@ -404,7 +404,7 @@ The value of this Event as a Number.
         try {
             def evtNumberValue = myState.numericValue
             log.debug "The numericValue of this event is ${evtNumberValue}"
-            log.debug "evt.numericValue instanceof BigDecimal? ${evtNumberValue instanceof BigDecimal}"
+            log.debug "evt.numericValue instanceof Number? ${evtNumberValue instanceof Number}"
         } catch (e) {
             log.debug("Trying to get the numericValue for ${myState.name} threw an exception", e)
         }
@@ -412,13 +412,13 @@ The value of this Event as a Number.
 
 ----
 
-unit
-----
+getUnit()
+---------
 
 The unit of measure for this Event, if applicable.
 
 **Signature:**
-    ``String unit``
+    ``String getUnit()``
 
 **Returns:**
     `String`_ - the unit of measure of this Event, if applicable. ``null`` otherwise.
@@ -434,13 +434,13 @@ The unit of measure for this Event, if applicable.
 
 ----
 
-value
------
+getValue()
+----------
 
 The value of this Event as a String.
 
 **Signature:**
-    ``String stringValue``
+    ``String getValue()``
 
 **Returns:**
     `String`_ - the value of this event as a String.
@@ -451,13 +451,13 @@ The value of this Event as a String.
 
     def eventHandler(evt) {
         def myState = app.currentState("someAttribute")
-        log.debug "The value of this event as a string: ${myState.value}"
+        log.debug "The value of this event as a string: ${myState.getValue()}"
     }
 
 ----
 
-xyzValue
---------
+getXyzValue()
+-------------
 
 Value of the event as a 3-entry Map with keys 'x', 'y', and 'z' with BigDecimal values. For example:
 
@@ -468,14 +468,14 @@ Value of the event as a 3-entry Map with keys 'x', 'y', and 'z' with BigDecimal 
 Typically only useful for getting position data from the "Three Axis" Capability.
 
 **Signature:**
-    ``Map<String, BigDecimal> xyzValue``
+    ``Map<String, BigDecimal> getXyzValue()``
 
 **Returns:**
     `Map`_ < `String`_ , `BigDecimal`_ > - A map representing the X, Y, and Z coordinates.
 
 .. warning::
 
-    ``xyzValue`` throws an Exception if the value of the Event cannot be parsed to an X-Y-Z data structure.
+    ``getXyzValue()`` throws an Exception if the value of the Event cannot be parsed to an X-Y-Z data structure.
 
     You should wrap calls in a try/catch block.
 

--- a/ref-docs/attribute-ref.rst
+++ b/ref-docs/attribute-ref.rst
@@ -13,21 +13,21 @@ You can get the supported Attributes of a Device through the Device's :ref:`supp
 
 .. warning::
 
-    Referring to an Attribute directly from a Device by calling ``someDevice.attributeName`` will return an Attribute object with only the ``name`` property available. This is available for legacy purposes only, and will likely be removed at some time.
+    Referring to an Attribute directly from a Device by calling ``someDevice.getAttributeName()`` will return an Attribute object with only the ``name`` property available. This is available for legacy purposes only, and will likely be removed at some time.
 
-    To get a reference to an Attribute object, you should use the ``supportedAttributes`` method on the Device object, and then find the desired Attribute in the returned List.
+    To get a reference to an Attribute object, you should use the ``getSupportedAttributes()`` method on the Device object, and then find the desired Attribute in the returned List.
 
 You can view the available attributes for all Capabilities in our :ref:`capabilities_taxonomy`.
 
 ----
 
-dataType
---------
+getDataType()
+-------------
 
 Gets the data type of this Attribute.
 
 **Signature:**
-    ``String dataType``
+    ``String getDataType()``
 
 **Returns:**
     `String`_ - the data type of this Attribute. Possible types are "STRING", "NUMBER", "VECTOR3", "ENUM".
@@ -50,13 +50,13 @@ Gets the data type of this Attribute.
 
 ----
 
-name
-----
+getName()
+---------
 
 The name of the Attribute.
 
 **Signature:**
-    ``String name``
+    ``String getName()``
 
 **Returns:**
     `String`_ - the name of this attribute
@@ -78,13 +78,13 @@ The name of the Attribute.
 
 ----
 
-values
-------
+getValues()
+-----------
 
 The possible values for this Attribute, if the data type is "ENUM".
 
 **Signature:**
-    ``List<String> values``
+    ``List<String> getValues()``
 
 **Returns:**
     `List`_ < `String`_ > - the possible values for this Attribute, if the data type is "ENUM". An empty list is returned if there are no possible values or if the data type is not "ENUM".

--- a/ref-docs/capability-ref.rst
+++ b/ref-docs/capability-ref.rst
@@ -15,42 +15,11 @@ For documentation for the available Capabilities, you can refer to the :ref:`cap
 
 ----
 
-name
-----
-
-The name of the capability.
+getAttributes()
+---------------
 
 **Signature:**
-    ``String name``
-
-**Returns:**
-    `String`_ - the name of the capability.
-
-**Example:**
-
-.. code-block:: groovy
-
-    preferences {
-        section() {
-            input "mySwitch", "capability.switch"
-        }
-    }
-    ...
-    def mySwitchCaps = mySwitch.capabilities
-
-    // log each capability supported by the "mySwitch" device
-    mySwitchCaps.each {cap ->
-        log.debug "Capability name: ${cap.name}"
-    }
-    ...
-
-----
-
-attributes
-----------
-
-**Signature:**
-    ``List<Attribute> attributes``
+    ``List<Attribute> getAttributes()``
 
 **Returns:**
     `List`_ <:ref:`attribute_ref`> - A list of Attributes of this capability. An empty list will be returned if this Capability has no Attributes.
@@ -79,11 +48,11 @@ attributes
 
 ----
 
-commands
---------
+getCommands()
+-------------
 
 **Signature:**
-    ``List<Command> commands``
+    ``List<Command> getCommands()``
 
 **Returns:**
     `List`_ <:ref:`command_ref`> - A list of Commands of this capability. An empty list will be returned if this Capability has no commands.
@@ -107,6 +76,37 @@ commands
         cap.commands.each {comm ->
             log.debug "-- Command name: ${comm.name}"
         }
+    }
+    ...
+
+----
+
+getName()
+---------
+
+The name of the capability.
+
+**Signature:**
+    ``String getName()``
+
+**Returns:**
+    `String`_ - the name of the capability.
+
+**Example:**
+
+.. code-block:: groovy
+
+    preferences {
+        section() {
+            input "mySwitch", "capability.switch"
+        }
+    }
+    ...
+    def mySwitchCaps = mySwitch.capabilities
+
+    // log each capability supported by the "mySwitch" device
+    mySwitchCaps.each {cap ->
+        log.debug "Capability name: ${cap.name}"
     }
     ...
 

--- a/ref-docs/command-ref.rst
+++ b/ref-docs/command-ref.rst
@@ -29,13 +29,13 @@ An instance of a Command object encapsulates information about that Command. You
 
 ----
 
-arguments
----------
+getArguments()
+--------------
 
 The list of argument types for the command.
 
 **Signature:**
-    ``List<String> arguments``
+    ``List<String> getArguments()``
 
 **Returns:**
     `List`_ < `String`_ > - A list of the argument types for this command. One of `"STRING"`, `"NUMBER"`, `"VECTOR3`", or `"ENUM"`.
@@ -57,16 +57,16 @@ The list of argument types for the command.
         log.debug "arguments for swithLevel command ${it.name}: ${it.arguments}"
     }
     ...
-    
+
 ----
 
-name
-----
+getName()
+---------
 
 The name of the command.
 
 **Signature:**
-    ``String name``
+    ``String getName()``
 
 **Returns:**
     `String`_ - the name of this command.

--- a/ref-docs/device-handler-ref.rst
+++ b/ref-docs/device-handler-ref.rst
@@ -1663,17 +1663,13 @@ Defines a tile that displays a specific value. Typical examples include temperat
 zigbee
 ------
 
-.. warning::
-
-    The documentation for this property is incomplete.
-
 A utility class for parsing and formatting ZigBee messages.
 
 **Signature:**
     ``Zigbee zigbee``
 
 **Returns:**
-    A reference to the ZigBee utility class.
+    A reference to the :ref:`ZigBee utility class <zigbee_ref>`.
 
 
 

--- a/ref-docs/device-ref.rst
+++ b/ref-docs/device-ref.rst
@@ -120,7 +120,7 @@ Some commands may take parameters; you will pass those parameters to the command
     theswitch.on([delay: 30000]) // send command after 30 seconds
     thethermostat.setHeatingSetpoint(72, [delay: 30000])
     ...
-    
+
 ----
 
 .. _currentAttributeName:
@@ -173,28 +173,6 @@ For example, the Carbon Monoxide Detector capability has an attribute "carbonMon
     log.debug "tempatt instanceof Number? ${tempattr instanceof Number}"
 
     ...
-
-----
-
-capabilities
-------------
-
-The List of Capabilities provided by this Device.
-
-**Signature:**
-    ``List<Capability> capabilities``
-
-**Returns:**
-    `List`_ <:ref:`capability_ref`> - a List of Capabilities supported by this Device.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def supportedCaps = somedevice.capabilities
-    supportedCaps.each {cap ->
-        log.debug "This device supports the ${cap.name} capability"
-    }
 
 ----
 
@@ -277,13 +255,35 @@ Gets the latest reported values of the specified attribute.
 
 ----
 
-displayName
------------
+getCapabilities()
+-----------------
+
+The List of Capabilities provided by this Device.
+
+**Signature:**
+    ``List<Capability> getCapabilities()``
+
+**Returns:**
+    `List`_ <:ref:`capability_ref`> - a List of Capabilities supported by this Device.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def supportedCaps = somedevice.capabilities
+    supportedCaps.each {cap ->
+        log.debug "This device supports the ${cap.name} capability"
+    }
+
+----
+
+getDisplayName()
+----------------
 
 The label of the Device assigned by the user.
 
 **Signature:**
-    ``String label``
+    ``String getDisplayName()``
 
 **Returns:**
     `String`_ - the label of the Device assigned by the user, ``null`` if no label iset.
@@ -301,16 +301,121 @@ The label of the Device assigned by the user.
 
 ----
 
-id
---
+getHub()
+--------
+
+The Hub associated with this Device.
+
+**Signature:**
+    ``Hub getHub()``
+
+**Returns:**
+    :ref:`hub_ref` - the Hub for this Device.
+
+**Example:**
+
+.. code-block:: groovy
+
+    log.debug "Hub: ${someDevice.hub.name}"
+
+----
+
+getId()
+-------
 
 The unique system identifier for this Device.
 
 **Signature:**
-    ``String id``
+    ``String getId()``
 
 **Returns:**
     `String`_ - the unique system identifer for this Device.
+
+----
+
+getLabel()
+----------
+
+The name of the Device set by the user in the mobile application or Web IDE.
+
+**Signature:**
+    ``String getLabel()``
+
+**Returns:**
+    `String`_ - the name of the Device as configured by the user.
+
+----
+
+getName()
+---------
+
+The internal name of the Device. Typically assigned by the system and editable only by a user in the IDE.
+
+**Signature:**
+    ``String getName()``
+
+**Returns:**
+    `String`_ - the internal name of the Device.
+
+----
+
+.. _supportedAttributes:
+
+getSupportedAttributes()
+------------------------
+
+The list of :ref:`attribute_ref` s for this Device.
+
+**Signature:**
+    ``List<Attribute> getSupportedAttributes()``
+
+**Returns:**
+    `List`_ <:ref:`attribute_ref`> - the list of Attributes for this Device. Includes both capability attributes as well as Device-specific attributes.
+
+**Example:**
+
+.. code-block:: groovy
+
+    preferences {
+        section() {
+            input "theswitch", "capability.switch"
+        }
+    }
+    ...
+    def theAtts = theswitch.supportedAttributes
+    theAtts.each {att ->
+        log.debug "Supported Attribute: ${att.name}"
+    }
+    ...
+
+----
+
+getSupportedCommands()
+----------------------
+
+The list of :ref:`command_ref` s for this Device.
+
+**Signature:**
+    ``List<Command> getSupportedCommands()``
+
+**Returns:**
+    `List`_ <:ref:`command_ref`> - the list of Commands for this Device. Includes both capability commands as well as Device-specific commands.
+
+**Example:**
+
+.. code-block:: groovy
+
+    preferences {
+        section() {
+            input "theswitch", "capability.switch"
+        }
+    }
+    ...
+    def theCommands = theswitch.supportedCommands
+    theCommands.each {com ->
+        log.debug "Supported Command: ${com.name}"
+    }
+    ...
 
 ----
 
@@ -569,25 +674,6 @@ Determine if this Device has the specified command name.
 
 ----
 
-hub
----
-
-The Hub associated with this Device.
-
-**Signature:**
-    ``Hub hub``
-
-**Returns:**
-    :ref:`hub_ref` - the Hub for this Device.
-
-**Example:**
-
-.. code-block:: groovy
-
-    log.debug "Hub: ${someDevice.hub.name}"
-
-----
-
 latestState()
 -------------
 
@@ -657,32 +743,6 @@ Get the latest reported value for the specified attribute.
 
     ...
 
-
-----
-
-name
-----
-
-The internal name of the Device. Typically assigned by the system and editable only by a user in the IDE.
-
-**Signature:**
-    ``String name``
-
-**Returns:**
-    `String`_ - the internal name of the Device.
-
-----
-
-label
------
-
-The name of the Device set by the user in the mobile application or Web IDE.
-
-**Signature:**
-    ``String label``
-
-**Returns:**
-    `String`_ - the name of the Device as configured by the user.
 
 ----
 
@@ -778,65 +838,6 @@ Get a list of Device :ref:`state_ref` objects for the specified attribute since 
     ...
 
 ----
-
-.. _supportedAttributes:
-
-supportedAttributes
--------------------
-
-The list of :ref:`attribute_ref` s for this Device.
-
-**Signature:**
-    ``List<Attribute> supportedAttributes``
-
-**Returns:**
-    `List`_ <:ref:`attribute_ref`> - the list of Attributes for this Device. Includes both capability attributes as well as Device-specific attributes.
-
-**Example:**
-
-.. code-block:: groovy
-
-    preferences {
-        section() {
-            input "theswitch", "capability.switch"
-        }
-    }
-    ...
-    def theAtts = theswitch.supportedAttributes
-    theAtts.each {att ->
-        log.debug "Supported Attribute: ${att.name}"
-    }
-    ...
-
-----
-
-supportedCommands
------------------
-
-The list of :ref:`command_ref` s for this Device.
-
-**Signature:**
-    ``List<Command> supportedCommands``
-
-**Returns:**
-    `List`_ <:ref:`command_ref`> - the list of Commands for this Device. Includes both capability commands as well as Device-specific commands.
-
-**Example:**
-
-.. code-block:: groovy
-
-    preferences {
-        section() {
-            input "theswitch", "capability.switch"
-        }
-    }
-    ...
-    def theCommands = theswitch.supportedCommands
-    theCommands.each {com ->
-        log.debug "Supported Command: ${com.name}"
-    }
-    ...
-
 
 .. _BigDecimal: http://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html
 .. _Boolean: http://docs.oracle.com/javase/7/docs/api/java/lang/Boolean.html

--- a/ref-docs/event-ref.rst
+++ b/ref-docs/event-ref.rst
@@ -9,61 +9,19 @@ Event instances are not created directly by SmartApp or Device Handlers. They ar
 
 .. note::
 
-    In a SmartApp or Device Handler, the method ``createEvent`` exists to create a Map that defines properties of an Event. Only by returning the resulting map from a Device Handler's ``parse`` method is an actual Event instance created and propagated through the SmartThings system.
+    In a SmartApp or Device Handler, the method ``createEvent()`` exists to create a Map that defines properties of an Event. Only by returning the resulting map from a Device Handler's ``parse()`` method is an actual Event instance created and propagated through the SmartThings system.
 
-The reference documentation here lists all properties and methods available on an Event object instance.
-
-----
-
-date
-----
-
-Acquisition time of this device state record.
-
-**Signature:**
-    ``Date date``
-
-**Returns:**
-    `Date`_ - the date and time this event record was created.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "event created at: ${evt.date}"
-    }
+The reference documentation here lists all methods available on an Event object instance.
 
 ----
 
-id
---
-
-The unique system identifier for this event.
-
-**Signature:**
-    ``String id``
-
-**Returns:**
-    `String`_ - the unique device identifier for this event.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "event id: ${evt.id}"
-    }
-
-----
-
-data
-----
+getData()
+---------
 
 A map of any additional data on the event.
 
 **Signature:**
-    ``String id``
+    ``String getData()``
 
 **Returns:**
     `Map`_ - A map of the additional data (if any) on the event.
@@ -88,15 +46,36 @@ Then in an event handler method, we can get at the data like this:
 
 ----
 
+getDate()
+---------
+
+Acquisition time of this device state record.
+
+**Signature:**
+    ``Date getDate()``
+
+**Returns:**
+    `Date`_ - the date and time this event record was created.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "event created at: ${evt.date}"
+    }
+
+----
+
 .. _event_date_value:
 
-dateValue
----------
+getDateValue()
+--------------
 
 The value of the event as a `Date`_ object, if applicable.
 
 **Signature:**
-    ``Date dateValue``
+    ``Date getDateValue()``
 
 **Returns:**
     `Date`_ - If the value of this event is date, a Date will be returned. ``null`` will be returned if the value of the event is not parseable to a Date.
@@ -113,13 +92,13 @@ The value of the event as a `Date`_ object, if applicable.
 
 ----
 
-description
------------
+getDescription()
+----------------
 
 The raw description that generated this Event.
 
 **Signature:**
-    ``String description``
+    ``String getDescription()``
 
 **Returns:**
     `String`_ - the raw description that generated this Event.
@@ -134,13 +113,13 @@ The raw description that generated this Event.
 
 ----
 
-descriptionText
----------------
+getDescriptionText()
+--------------------
 
 The description of the event that is to be displayed to the user in the mobile application.
 
 **Signature:**
-    ``String descriptionText``
+    ``String getDescriptionText()``
 
 **Returns:**
     `String`_ - the description of this event to be displayed to the user in the mobile application.
@@ -155,24 +134,24 @@ The description of the event that is to be displayed to the user in the mobile a
 
 ----
 
-device
-------
+getDevice()
+-----------
 
 The :ref:`device_ref` associated with this Event.
 
 **Signature:**
-    ``Device device``
+    ``Device getDevice()``
 
 **Returns:**
     :ref:`device_ref` - the Device associated with this Event, or ``null`` if no Device is associated with this Event.
 
 ----
 
-displayName
------------
+getDisplayName()
+----------------
 
 **Signature:**
-    ``String displayName``
+    ``String getDisplayName()``
 
 **Returns:**
     `String`_ - The user-friendly name of the source of this event. Typically the user-assigned device label.
@@ -187,13 +166,13 @@ displayName
 
 ----
 
-deviceId
---------
+getDeviceId()
+-------------
 
 The unique system identifer of the :ref:`device_ref` associated with this Event.
 
 **Signature:**
-    ``String deviceId``
+    ``String getDeviceId()``
 
 **Returns:**
     `String`_  - the unique system identifier of the device assocaited with this Event, or null if there is no device associated with this Event.
@@ -208,15 +187,36 @@ The unique system identifer of the :ref:`device_ref` associated with this Event.
 
 ----
 
+getId()
+-------
+
+The unique system identifier for this event.
+
+**Signature:**
+    ``String getId()``
+
+**Returns:**
+    `String`_ - the unique device identifier for this event.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "event id: ${evt.id}"
+    }
+
+----
+
 .. _event_ref_double_value:
 
-doubleValue
------------
+getDoubleValue()
+----------------
 
 The value of this Event, if the value can be parsed to a Double.
 
 **Signature:**
-    ``Double doubleValue``
+    ``Double getDoubleValue()``
 
 **Returns:**
     `Double`_ - the value of this Event as a Double.
@@ -244,13 +244,13 @@ The value of this Event, if the value can be parsed to a Double.
 
 ----
 
-floatValue
-----------
+getFloatValue()
+---------------
 
 The value of this Event as a Float, if it can be parsed into a Float.
 
 **Signature:**
-    ``Float foatValue``
+    ``Float getFloatValue()``
 
 **Returns:**
     `Float`_ - the value of this Event as a Float.
@@ -278,17 +278,13 @@ The value of this Event as a Float, if it can be parsed into a Float.
 
 ----
 
-.. hub
-.. ~~~~
-.. ----
-
-hubId
------
+getHubId()
+----------
 
 The unique system identifer of the Hub associated with this Event.
 
 **Signature:**
-    ``String hubId``
+    ``String getHubId()``
 
 **Returns:**
     `String`_ - the unique system identifier of the Hub associated with this Event, or ``null`` if no Hub is associated with this Event.
@@ -303,13 +299,13 @@ The unique system identifer of the Hub associated with this Event.
 
 ----
 
-installedSmartAppId
--------------------
+getInstalledSmartAppId()
+------------------------
 
 The unique system identifier of the SmartApp instance associated with this Event.
 
 **Signature:**
-    ``String installedSmartApp``
+    ``String getInstalledSmartAppId()``
 
 **Returns:**
     `String`_ - the unique system identifier of the SmartApp instance associated with this Event.
@@ -324,13 +320,13 @@ The unique system identifier of the SmartApp instance associated with this Event
 
 ----
 
-integerValue
-------------
+getIntegerValue()
+-----------------
 
 The value of this Event as an Integer.
 
 **Signature:**
-    ``Integer integerValue``
+    ``Integer getIntegerValue()``
 
 **Returns:**
     `Integer`_ - the value of this Event as an Integer.
@@ -358,6 +354,362 @@ The value of this Event as an Integer.
 
 ----
 
+getIsoDate()
+------------
+
+Acquisition time of this Event as an ISO-8601 String.
+
+**Signature:**
+    ``String getIsoDate()``
+
+**Returns:**
+    `String`_ - The acquisition time of this Event as an ISO-8601 String.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "event isoDate: ${evt.isoDate}"
+    }
+
+----
+
+getJsonValue()
+--------------
+
+Value of the Event as a parsed JSON data structure.
+
+**Signature:**
+    ``Object getJsonValue()``
+
+**Returns:**
+    `Object`_ - The value of the Event as a JSON structure
+
+.. warning::
+
+    ``jsonValue`` throws an Exception if the value of the Event cannot be parsed into a JSON object.
+
+    You should wrap calls in a try/catch block.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        // get the value of this event as a JSON structure
+        // throws an exception if the value is not convertable to JSON
+        try {
+            log.debug "The jsonValue of this event is ${evt.jsonValue}"
+        } catch (e) {
+            log.debug("Trying to get the jsonValue for ${evt.name} threw an exception", e)
+        }
+    }
+
+----
+
+getLinkText()
+-------------
+
+.. warning::
+
+    Deprecated.
+
+    ``getLinkText()`` is deprecated. Use `displayName`_ instead.
+
+The user-friendly name of the source of this event. Typically the user-assigned device label.
+
+----
+
+getLocation()
+-------------
+
+The Location associated with this Event.
+
+**Signature:**
+    ``Location getLocation()``
+
+**Returns:**
+    :ref:`location_ref` - The Location associated with this Event, or ``null`` if no Location is associated with this Event.
+
+----
+
+getLocationId()
+---------------
+
+The unique system identifier for the :ref:`location_ref` associated with this Event.
+
+**Signature:**
+    ``String getLocationId()``
+
+**Returns:**
+    `String`_ - the unique system identifier for the :ref:`location_ref` associated with this Event.
+
+----
+
+getLongValue()
+--------------
+
+The value of this Event as a Long.
+
+**Signature:**
+    ``Long getLongValue()``
+
+**Returns:**
+    `Long`_ - the value of this Event as a Long.
+
+.. warning::
+
+    ``longValue`` throws an Exception if the value of the Event cannot be parsed to a Long.
+
+    You should wrap calls in a try/catch block.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        // get the value of this event as an Long
+        // throws an exception if not convertable to Long
+        try {
+            def evtLongValue = evt.longVaue
+            log.debug "The longValue of this event is evtLongValue"
+            log.debug "evt.longValue instanceof Long? ${evtLongValue instanceof Long}"
+        } catch (e) {
+            log.debug("Trying to get the longValue for ${evt.name} threw an exception", e)
+        }
+    }
+
+----
+
+getName()
+---------
+
+The name of this Event.
+
+**Signature:**
+    ``String getName()``
+
+**Returns:**
+    `String`_ - the name of this event.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "the name of this event: ${evt.name}"
+    }
+
+----
+
+getNumberValue()
+----------------
+
+The value of this Event as a Number.
+
+**Signature:**
+    ``Number getNumberValue()``
+
+**Returns:**
+    `Number`_ - the value of this event as a Number.
+
+.. warning::
+
+    ``numberValue`` throws an Exception if the value of the Event cannot be parsed to a Number.
+
+    You should wrap calls in a try/catch block.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        // get the value of this event as an Number
+        // throws an exception if the value is not convertable to a Number
+        try {
+            def evtNumberValue = evt.numberValue
+            log.debug "The numberValue of this event is ${evtNumberValue}"
+            log.debug "evt.numberValue instanceof Number? ${evtNumberValue instanceof Number}"
+        } catch (e) {
+            log.debug("Trying to get the numberValue for ${evt.name} threw an exception", e)
+        }
+    }
+
+----
+
+getNumericValue()
+-----------------
+
+The value of this Event as a Number.
+
+**Signature:**
+    ``Number getNumericValue()``
+
+**Returns:**
+    `Number`_ - the value of this event as a Number.
+
+.. warning::
+
+    ``numericValue`` throws an Exception if the value of the Event cannot be parsed to a Number.
+
+    You should wrap calls in a try/catch block.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        // get the value of this event as an Number
+        // throws an exception if the value is not convertable to a Number
+        try {
+            def evtNumberValue = evt.numericValue
+            log.debug "The numericValue of this event is ${evtNumberValue}"
+            log.debug "evt.numericValue instanceof Number? ${evtNumberValue instanceof Number}"
+        } catch (e) {
+            log.debug("Trying to get the numericValue for ${evt.name} threw an exception", e)
+        }
+    }
+
+----
+
+getSource()
+-----------
+
+The source of the Event.
+
+**Signature:**
+    ``String getSource()``
+
+**Returns:**
+    `String`_ - the source of the Event. The following table lists the possible sources and their meaning:
+
+    ================ ===========
+    Source           Description
+    ================ ===========
+    `"APP"`          Event originated by an app touch event in the mobile application.
+    `"APP_COMMAND"`  Event originated by using the mobile application (for example, using the mobile application to turn a light off)
+    `"COMMAND"`      Event originated by a SmartApp or Device Handler calling a command on a device.
+    `"DEVICE`"       Event originated by the physical actuation of a device.
+    `"HUB"`          Event originated on the hub.
+    `"LOCATION"`     Event originated by a Location state change (for example, sunrise and sunset events)
+    `"USER"`
+    ================ ===========
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "The source of this event is: ${evt.source}"
+    }
+
+----
+
+getStringValue()
+----------------
+
+The value of this Event as a String.
+
+**Signature:**
+    ``String getStringValue()``
+
+**Returns:**
+    `String`_ - the value of this event as a String.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "The value of this event as a string: ${evt.stringValue}"
+    }
+
+----
+
+getUnit()
+---------
+
+The unit of measure for this Event, if applicable.
+
+**Signature:**
+    ``String getUnit()``
+
+**Returns:**
+    `String`_ - the unit of measure of this Event, if applicable. ``null`` otherwise.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "The unit for this event: ${evt.unit}"
+    }
+
+----
+
+getValue()
+----------
+
+The value of this Event as a String.
+
+**Signature:**
+    ``String getValue()``
+
+**Returns:**
+    `String`_ - the value of this event as a String.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def eventHandler(evt) {
+        log.debug "The value of this event as a string: ${evt.value}"
+    }
+
+----
+
+getXyzValue()
+-------------
+
+Value of the event as a 3-entry Map with keys 'x', 'y', and 'z' with BigDecimal values. For example:
+
+.. code-block:: groovy
+
+    [x: 1001, y: -23, z: -1021]
+
+Typically only useful for getting position data from the "Three Axis" Capability.
+
+**Signature:**
+    ``Map<String, BigDecimal> getXyzValue()``
+
+**Returns:**
+    `Map`_ < `String`_ , `BigDecimal`_ > - A map representing the X, Y, and Z coordinates.
+
+.. warning::
+
+    ``xyzValue`` throws an Exception if the value of the Event cannot be parsed to an X-Y-Z data structure.
+
+    You should wrap calls in a try/catch block.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def positionChangeHandler(evt) {
+        // get the value of this event as a 3 entry map with keys
+        //'x', 'y', 'z', and BigDecimal values
+        // throws an exception if the value is not convertable to a Date
+        try {
+            log.debug "The xyzValue of this event is ${evt.xyzValue }"
+            log.debug "evt.xyzValue instanceof Map? ${evt.xyzValue  instanceof Map}"
+        } catch (e) {
+            log.debug("Trying to get the xyzValue for ${evt.name} threw an exception", e)
+        }
+    }
+
+----
+
 isDigital()
 -----------
 
@@ -375,27 +727,6 @@ isDigital()
 
     def eventHandler(evt) {
         log.debug "event from digital actuation? ${evt.isDigital()}"
-    }
-
-----
-
-isoDate
--------
-
-Acquisition time of this Event as an ISO-8601 String.
-
-**Signature:**
-    ``String isoDate``
-
-**Returns:**
-    `String`_ - The acquisition time of this Event as an ISO-8601 String.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "event isoDate: ${evt.isoDate}"
     }
 
 ----
@@ -441,339 +772,6 @@ isStateChange()
     }
 
 ----
-
-jsonValue
----------
-
-Value of the Event as a parsed JSON data structure.
-
-**Signature:**
-    ``Object jsonValue``
-
-**Returns:**
-    `Object`_ - The value of the Event as a JSON structure
-
-.. warning::
-
-    ``jsonValue`` throws an Exception if the value of the Event cannot be parsed into a JSON object.
-
-    You should wrap calls in a try/catch block.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        // get the value of this event as a JSON structure
-        // throws an exception if the value is not convertable to JSON
-        try {
-            log.debug "The jsonValue of this event is ${evt.jsonValue}"
-        } catch (e) {
-            log.debug("Trying to get the jsonValue for ${evt.name} threw an exception", e)
-        }
-    }
-
-----
-
-linkText
---------
-
-.. warning::
-
-    Deprecated.
-
-    Using the ``linkText`` property is deprecated. Use `displayName`_ instead.
-
-The user-friendly name of the source of this event. Typically the user-assigned device label.
-
-----
-
-location
---------
-
-The Location associated with this Event.
-
-**Signature:**
-    ``Location location``
-
-**Returns:**
-    :ref:`location_ref` - The Location associated with this Event, or ``null`` if no Location is associated with this Event.
-
-----
-
-locationId
-----------
-
-The unique system identifier for the :ref:`location_ref` associated with this Event.
-
-**Signature:**
-    ``String locationId``
-
-**Returns:**
-    `String`_ - the unique system identifier for the :ref:`location_ref` associated with this Event.
-
-----
-
-longValue
----------
-
-The value of this Event as a Long.
-
-**Signature:**
-    ``Long longValue``
-
-**Returns:**
-    `Long`_ - the value of this Event as a Long.
-
-.. warning::
-
-    ``longValue`` throws an Exception if the value of the Event cannot be parsed to a Long.
-
-    You should wrap calls in a try/catch block.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        // get the value of this event as an Long
-        // throws an exception if not convertable to Long
-        try {
-            def evtLongValue = evt.longVaue
-            log.debug "The longValue of this event is evtLongValue"
-            log.debug "evt.longValue instanceof Long? ${evtLongValue instanceof Long}"
-        } catch (e) {
-            log.debug("Trying to get the longValue for ${evt.name} threw an exception", e)
-        }
-    }
-
-----
-
-name
-----
-
-The name of this Event.
-
-**Signature:**
-    ``String name``
-
-**Returns:**
-    `String`_ - the name of this event.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "the name of this event: ${evt.name}"
-    }
-
-----
-
-numberValue
------------
-
-The value of this Event as a Number.
-
-**Signature:**
-    ``BigDecimal numberValue``
-
-**Returns:**
-    `BigDecimal`_ - the value of this event as a BigDecimal.
-
-.. warning::
-
-    ``numberValue`` throws an Exception if the value of the Event cannot be parsed to a BigDecimal.
-
-    You should wrap calls in a try/catch block.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        // get the value of this event as an Number
-        // throws an exception if the value is not convertable to a Number
-        try {
-            def evtNumberValue = evt.numberValue
-            log.debug "The numberValue of this event is ${evtNumberValue}"
-            log.debug "evt.numberValue instanceof BigDecimal? ${evtNumberValue instanceof BigDecimal}"
-        } catch (e) {
-            log.debug("Trying to get the numberValue for ${evt.name} threw an exception", e)
-        }
-    }
-
-----
-
-numericValue
-------------
-
-The value of this Event as a Number.
-
-**Signature:**
-    ``BigDecimal numericValue``
-
-**Returns:**
-    `BigDecimal`_ - the value of this event as a BigDecimal.
-
-.. warning::
-
-    ``numericValue`` throws an Exception if the value of the Event cannot be parsed to a BigDecimal.
-
-    You should wrap calls in a try/catch block.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        // get the value of this event as an Number
-        // throws an exception if the value is not convertable to a Number
-        try {
-            def evtNumberValue = evt.numericValue
-            log.debug "The numericValue of this event is ${evtNumberValue}"
-            log.debug "evt.numericValue instanceof BigDecimal? ${evtNumberValue instanceof BigDecimal}"
-        } catch (e) {
-            log.debug("Trying to get the numericValue for ${evt.name} threw an exception", e)
-        }
-    }
-
-----
-
-source
-------
-
-The source of the Event.
-
-**Signature:**
-    ``String source``
-
-**Returns:**
-    `String`_ - the source of the Event. The following table lists the possible sources and their meaning:
-
-    ================ ===========
-    Source           Description
-    ================ ===========
-    `"APP"`          Event originated by an app touch event in the mobile application.
-    `"APP_COMMAND"`  Event originated by using the mobile application (for example, using the mobile application to turn a light off)
-    `"COMMAND"`      Event originated by a SmartApp or Device Handler calling a command on a device.
-    `"DEVICE`"       Event originated by the physical actuation of a device.
-    `"HUB"`          Event originated on the hub.
-    `"LOCATION"`     Event originated by a Location state change (for example, sunrise and sunset events)
-    `"USER"`
-    ================ ===========
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "The source of this event is: ${evt.source}"
-    }
-
-----
-
-stringValue
------------
-
-The value of this Event as a String.
-
-**Signature:**
-    ``String stringValue``
-
-**Returns:**
-    `String`_ - the value of this event as a String.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "The value of this event as a string: ${evt.stringValue}"
-    }
-
-----
-
-unit
-----
-
-The unit of measure for this Event, if applicable.
-
-**Signature:**
-    ``String unit``
-
-**Returns:**
-    `String`_ - the unit of measure of this Event, if applicable. ``null`` otherwise.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "The unit for this event: ${evt.unit}"
-    }
-
-----
-
-value
------
-
-The value of this Event as a String.
-
-**Signature:**
-    ``String stringValue``
-
-**Returns:**
-    `String`_ - the value of this event as a String.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def eventHandler(evt) {
-        log.debug "The value of this event as a string: ${evt.value}"
-    }
-
-----
-
-xyzValue
---------
-
-Value of the event as a 3-entry Map with keys 'x', 'y', and 'z' with BigDecimal values. For example:
-
-.. code-block:: groovy
-
-    [x: 1001, y: -23, z: -1021]
-
-Typically only useful for getting position data from the "Three Axis" Capability.
-
-**Signature:**
-    ``Map<String, BigDecimal> xyzValue``
-
-**Returns:**
-    `Map`_ < `String`_ , `BigDecimal`_ > - A map representing the X, Y, and Z coordinates.
-
-.. warning::
-
-    ``xyzValue`` throws an Exception if the value of the Event cannot be parsed to an X-Y-Z data structure.
-
-    You should wrap calls in a try/catch block.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def positionChangeHandler(evt) {
-        // get the value of this event as a 3 entry map with keys
-        //'x', 'y', 'z', and BigDecimal values
-        // throws an exception if the value is not convertable to a Date
-        try {
-            log.debug "The xyzValue of this event is ${evt.xyzValue }"
-            log.debug "evt.xyzValue instanceof Map? ${evt.xyzValue  instanceof Map}"
-        } catch (e) {
-            log.debug("Trying to get the xyzValue for ${evt.name} threw an exception", e)
-        }
-    }
 
 .. _BigDecimal: http://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html
 .. _Boolean: http://docs.oracle.com/javase/7/docs/api/java/lang/Boolean.html

--- a/ref-docs/hub-ref.rst
+++ b/ref-docs/hub-ref.rst
@@ -31,11 +31,11 @@ Below are the available properties on a Hub:
 ----
 
 
-firmareVersionString
---------------------
+getFirmwareVersionString()
+--------------------------
 
 **Signature:**
-    ``String firmwareVersionString``
+    ``String getFirmwareVersionString()()``
 
 **Returns:**
     `String`_ - The firmware version of the Hub
@@ -50,13 +50,13 @@ firmareVersionString
 
 ----
 
-id
---
+getId()
+-------
 
 The unique system identifier for this Hub.
 
 **Signature:**
-    ``String id``
+    ``String getId()``
 
 **Returns:**
     `String`_ - the unique device identifier for this Hub.
@@ -71,78 +71,78 @@ The unique system identifier for this Hub.
 
 ----
 
-localIP
--------
+getLocalIP()
+------------
 
 The local IP address of the Hub.
 
 **Signature:**
-    ``String localIP``
+    ``String getLocalIP()``
 
 **Returns:**
     `String`_ - The IP address of the Hub.
 
 ----
 
-localSrvPortTCP
----------------
+getLocalSrvPortTCP()
+--------------------
 
 The local server TCP port of the Hub.
 
 **Signature:**
-    ``String localSrvPortTCP``
+    ``String getLocalSrvPortTCP()``
 
 **Returns:**
     `String`_ - the TCP port for the Hub.
 
 ----
 
-name
-----
+getName()
+---------
 
 The name of the Hub.
 
 **Signature:**
-    ``String name``
+    ``String getName()``
 
 **Returns:**
     `String`_ - the name of the Hub.
 
 ----
 
-type
-----
+getType()
+---------
 
 The type of the Hub. Either "PHYSICAL" or "VIRTUAL".
 
 **Signature:**
-    ``String type``
+    ``String getType()``
 
 **Returns:**
     `String`_ - the type of the hub.
 
 ----
 
-zigbeeEui
----------
+getZigbeeEui()
+--------------
 
 The ZigBee Extended Unique Identifier of the Hub.
 
 **Signature:**
-    ``String zigbeeEui``
+    ``String getZigbeeEui()``
 
 **Returns:**
     `String`_ - The ZigBee EUI
 
 ----
 
-zigbeeId
---------
+getZigbeeId()
+-------------
 
 The ZigBee ID of the Hub.
 
 **Signature:**
-    ``String zigbeeId``
+    ``String getZigbeeId()``
 
 **Returns:**
     `String`_  - the ZigBee ID

--- a/ref-docs/installed-smart-app-wrapper-ref.rst
+++ b/ref-docs/installed-smart-app-wrapper-ref.rst
@@ -10,8 +10,8 @@ Every SmartApp has an instance of ``InstalledSmartApp`` available to it via the 
 
 ----
 
-currentState
-------------
+currentState()
+--------------
 
 Gets the current state of the given attribute.
 
@@ -35,8 +35,8 @@ Gets the current state of the given attribute.
 
 ----
 
-appSettings
------------
+getAppSettings()
+----------------
 
 Gets the settings currently associated with this SmartApp.
 
@@ -44,23 +44,23 @@ Gets the settings currently associated with this SmartApp.
     This method applies to the SmartApp's :ref:`app_settings`.
 
 **Signature:**
-    ``Map`` app.appSettings
+    ``Map`` app.getAppSettings()
 
 **Returns:**
     `Map`_ - A map of key, value pairs that represent the current SmartApp settings
 
 ----
 
-childApps
-------------
+getChildApps()
+--------------
 
 Gets a list of child apps associated with this SmartApp.
 
 **Signature:**
-    ``InstalledSmartApp[]`` childApps
+    ``List<InstalledSmartApp> getChildApps()``
 
 **Returns:**
-    `InstalledSmartApp[]` - A list of child SmartApps
+    `List`_ < :ref:`installed_smart_app_wrapper` > - A list of child SmartApps
 
 **Example:**
 
@@ -77,16 +77,16 @@ Gets a list of child apps associated with this SmartApp.
 
 ----
 
-childDevices
----------------
+getChildDevices()
+-----------------
 
 Gets a list of child devices associated with this SmartApp.
 
 **Signature:**
-    ``DeviceWrapper[]`` app.childDevices
+    ``List<Device>`` getChildDevices()
 
 **Returns:**
-    `DeviceWrapper[]` - A list of child devices
+    `List`_ < :ref:`device_ref` > - A list of child devices
 
 **Example:**
 
@@ -109,124 +109,124 @@ Gets a list of child devices associated with this SmartApp.
 
 ----
 
-executionIsModeRestricted
-----------------------------
+getExecutionIsModeRestricted()
+------------------------------
 
 Returns `true` if the SmartApp's execution is restricted by modes.
 The restrictive modes would have been configured when the SmartApp was installed.
 
 **Signature:**
-    ``Boolean`` executionIsModeRestricted()
+    ``Boolean`` getExecutionIsModeRestricted()()
 
 **Returns:**
     `Boolean`_ - True if the execution of the SmartApp is restricted to certain modes
 
 ----
 
-executableModes
-------------------
+getExecutableModes()
+--------------------
 
 Get a list of modes that this SmartApp is allowed to execute in.
 
 **Signature:**
-    :ref:`mode_ref` executableModes
+    :ref:`mode_ref` getExecutableModes()
 
 **Returns:**
     :ref:`mode_ref` - A list of modes that this SmartApp is allowed to execute in
 
 ----
 
-id
---
+getId()
+-------
 
 Get the id of the SmartApp
 
 **Signature:**
-    app.id
+    ``String getId()``
 
 **Returns:**
     The ID of the SmartApp
 
 ----
 
-installationState
------------------
+getInstallationState()
+----------------------
 
 Get the current installation state of the SmartApp.
 
 **Signature:**
-    app.installationState
+    ``String getInstallationState()``
 
 **Returns:**
     The current installation state of the SmartApp. Can be ``incomplete`` or ``complete``
 
 ----
 
-label
------
+getLabel()
+----------
 
 Get the label of the SmartApp
 
 **Signature:**
-    app.label
+    ``String getLabel()``
 
 **Returns:**
     The label of the SmartApp
 
 ----
 
-name
-----
+getName()
+---------
 
 Get the name of the SmartApp
 
 **Signature:**
-    app.name
+    ``String getName()``
 
 **Returns:**
     The name of the SmartApp
 
 ----
 
-getNamespace
-------------
+getNamespace()
+--------------
 
 Get the namespace of the SmartApp
 
 **Signature:**
-    app.namespace
+    ``String getNamespace()``
 
 **Returns:**
     The namespace of the SmartApp
 
 ----
 
-parent
-------
+getParent()
+-----------
 
 Gets the parent of the SmartApp.
 
 **Signature:**
-    ``InstalledSmartApp`` app.parent
+    :ref:`installed_smart_app_wrapper` getParent()
 
 **Returns:**
-    `InstalledSmartApp` - The parent of this SmartApp
+    :ref:`installed_smart_app_wrapper` - The parent of this SmartApp
 
 ----
 
-subscriptions
--------------
+getSubscriptions()
+------------------
 
 **Signature:**
-    ``EventSubscriptionWrapper[]`` app.subscriptions
+    ``List<EventSubscriptionWrapper>`` getSubscriptions()
 
 **Returns**
-    `EventSubscriptionWrapper[]` - A list of subscriptions associated with this SmartApp
+    `List<EventSubscriptionWrapper[]` - A list of subscriptions associated with this SmartApp
 
 ----
 
-statesBetween
--------------
+statesBetween()
+---------------
 
 Get a list of app :ref:`app_state` objects for the specified attribute between the specified times in reverse chronological order (newest first).
 
@@ -269,7 +269,7 @@ Get a list of app :ref:`app_state` objects for the specified attribute between t
 
 ----
 
-statesSince
+statesSince()
 -------------
 
 Get a list of app :ref:`app_state` objects for the specified attribute since the date specified.
@@ -307,13 +307,13 @@ Get a list of app :ref:`app_state` objects for the specified attribute since the
 
 ----
 
-updateLabel
------------
+updateLabel()
+-------------
 
 Update the label of this SmartApp.
 
 **Signature:**
-    ``void`` app.updateLabel(String label)
+    ``void updateLabel(String label)``
 
 **Parameters:**
     `String`_ label - The updated label value

--- a/ref-docs/location-ref.rst
+++ b/ref-docs/location-ref.rst
@@ -11,26 +11,26 @@ All SmartApps and Device Handlers are injected with a ``location`` property that
 
 .. _location_contact_book_enabled:
 
-contactBookEnabled
-------------------
+getContactBookEnabled()
+-----------------------
 
 ``true`` if this location has contact book enabled (has contacts), ``false`` otherwise.
 
 **Signature:**
-    ``Boolean contactBookEnabled``
+    ``Boolean getContactBookEnabled()``
 
 **Returns:**
     ``true`` if this location has contact book enabled (has contacts), ``false`` otherwise.
 
 ----
 
-currentMode
------------
+getCurrentMode()
+----------------
 
 The current Mode for the Location.
 
 **Signature:**
-    ``Mode currentMode``
+    ``Mode getCurrentMode()``
 
 **Returns:**
     :ref:`mode_ref` - The current mode for the Location.
@@ -43,13 +43,13 @@ The current Mode for the Location.
 
 ----
 
-id
---
+getId()
+-------
 
 The unique internal system identifier for the Location.
 
 **Signature:**
-    ``String id``
+    ``String getId()``
 
 **Returns:**
     `String`_ - the unique internal system identifier for the Location.
@@ -62,13 +62,13 @@ The unique internal system identifier for the Location.
 
 ----
 
-hubs
-----
+getHubs()
+---------
 
 The list of Hubs for this location. Currently only Hub can be installed into a Location, thought this API returns a List to allow for future expandability.
 
 **Signature:**
-    ``List<Hub> hubs``
+    ``List<Hub> getHubs()``
 
 **Returns:**
     List <:ref:`hub_ref`> - the Hubs for this Location.
@@ -81,13 +81,13 @@ The list of Hubs for this location. Currently only Hub can be installed into a L
 
 ----
 
-latitude
---------
+getLatitude()
+-------------
 
 Geographical latitude of the location. Southern latitudes are negative. Requires that location services are enabled in the mobile app.
 
 **Signature:**
-    ``BigDecimal latitude``
+    ``BigDecimal getLatitude()``
 
 **Returns:**
     `BigDecimal`_ - the latitude for the Location.
@@ -100,13 +100,13 @@ Geographical latitude of the location. Southern latitudes are negative. Requires
 
 ----
 
-longitude
----------
+getLongitude()
+--------------
 
 Geographical longitude of the location. Western longitudes are negative. Requires that location services are enabled in the mobile app.
 
 **Signature:**
-    ``BigDecimal longitude``
+    ``BigDecimal getLongitude()``
 
 **Returns:**
     `BigDecimal`_ - the longitude for the Location.
@@ -119,13 +119,13 @@ Geographical longitude of the location. Western longitudes are negative. Require
 
 ----
 
-mode
-----
+getMode()
+---------
 
 The current Mode name for the Location.
 
 **Signature:**
-    ``String mode``
+    ``String getMode()``
 
 **Returns:**
     `String`_ - the name of the current Mode for the Location.
@@ -138,13 +138,13 @@ The current Mode name for the Location.
 
 ----
 
-modes
------
+getModes()
+----------
 
 List of Modes for the Location.
 
 **Signature:**
-    ``List<Mode> modes``
+    ``List<Mode> getModes()``
 
 **Returns:**
     `List`_ <:ref:`mode_ref`> - the List of Modes for the Location.
@@ -157,13 +157,13 @@ List of Modes for the Location.
 
 ----
 
-name
-----
+getName()
+---------
 
 The name of the Location, as assigned by the user.
 
 **Signature:**
-    ``String name``
+    ``String getName()``
 
 **Returns:**
     `String`_ - the name of the Location as assigned by the user.
@@ -203,13 +203,15 @@ Set the mode for this location.
         location.setMode("Home")
     }
 
-temperatureScale
-----------------
+----
+
+getTemperatureScale()
+---------------------
 
 The temperature scale ("F" for fahrenheit, "C" for celsius) for this location.
 
 **Signature:**
-    ``String temperatureScale``
+    ``String getTemperatureScale()``
 
 **Returns:**
     `String`_ - the temperature scale set for this location. Either "F" for fahrenheit or "C" for celsius.
@@ -221,13 +223,15 @@ The temperature scale ("F" for fahrenheit, "C" for celsius) for this location.
     def tempScale = location.temperatureScale
     log.debug "Temperature scale for this location is $tempScale"
 
-timeZone
---------
+----
+
+getTimeZone()
+-------------
 
 The time zone for the Location. Requires that location services are enabled in the mobile application.
 
 **Signature:**
-    ``TimeZone timeZone``
+    ``TimeZone getTimeZone()``
 
 **Returns:**
     `TimeZone`_ - the time zone for the Location.
@@ -240,13 +244,13 @@ The time zone for the Location. Requires that location services are enabled in t
 
 ----
 
-zipCode
--------
+getZipCode()
+------------
 
 The ZIP code for the Location, if in the USA. Requires that location services be enabled in the mobile application.
 
 **Signature:**
-    ``String zipCode``
+    ``String getZipCode()``
 
 **Returns:**
     `String`_ - the ZIP code for the Location.

--- a/ref-docs/mode-ref.rst
+++ b/ref-docs/mode-ref.rst
@@ -17,13 +17,13 @@ SmartThings developers cannot create a new Mode. The most common way to interact
 
 ----
 
-id
---
+getId()
+-------
 
 The unique internal system identifier of the Mode.
 
 **Signature:**
-    ``String id``
+    ``String getId()``
 
 **Returns:**
     `String`_ - the unique internal system identifier for the Mode.
@@ -35,13 +35,13 @@ The unique internal system identifier of the Mode.
 
 ----
 
-name
-----
+getName()
+---------
 
 The name of the Mode.
 
 **Signature:**
-    ``String name``
+    ``String getName()``
 
 **Returns:**
     `String`_ - the name of the Mode, usually assigned by the user.

--- a/ref-docs/reference.rst
+++ b/ref-docs/reference.rst
@@ -33,13 +33,13 @@ This powerful feature can make documenting all available methods difficult, sinc
 
 *Conventions*
 
-All methods and properties are listed in alphabetical order, with the exception of SmartApp and Device Handler methods that are expected to be defined by SmartApps and Device Handlers - those will be listed first.
-
-Methods are listed with a ``()`` after the name. Properties do not have a ``()``. For example: ``subscribe()`` is a method, ``floatValue`` is a property.
+All methods are listed in alphabetical order, with the exception of SmartApp and Device Handler methods that are expected to be defined by SmartApps and Device Handlers - those will be listed first.
 
 .. note::
 
-    Groovy follows the JavaBean convention, and adds some syntactic sugar on top. Any zero-arg getter can be retrieved via property access directly. For example, ``isPhysical()`` *could* be invoked as ``physical``. Because this relies upon details of the backing internal object, we recommend that you use the documented version.
+    Groovy follows the JavaBean convention, and adds some syntactic sugar on top. Any zero-arg getter can be retrieved via property access directly.
+    For example, ``getName()`` could be invoked as ``name``.
+    You'll see this shortcut syntax often in Groovy and SmartThings.
 
 Some methods may have many signatures. For example, the ``schedule`` method available to SmartApps can be called with a variety of arguments. We have documented all forms in one location (``schedule()``). All supported signatures will be listed, as well as all parameters for the various signatures.
 

--- a/ref-docs/smartapp-ref.rst
+++ b/ref-docs/smartapp-ref.rst
@@ -16,7 +16,7 @@ The following methods should be defined by all SmartApps. They are called by the
 .. _smartapp_installed:
 
 installed()
-~~~~~~~~~~~
+-----------
 
 .. note::
 
@@ -45,7 +45,7 @@ Called when an instance of the app is installed. Typically subscribes to events 
 .. _smartapp_updated:
 
 updated()
-~~~~~~~~~
+---------
 
 .. note::
 
@@ -72,7 +72,7 @@ Called when the preferences of an installed app are updated. Typically unsubscri
 ----
 
 uninstalled()
-~~~~~~~~~~~~~
+-------------
 
 .. note::
 
@@ -100,7 +100,7 @@ Called, if declared, when an app is uninstalled. Does not need to be declared un
 The following methods and attributes are available to call in a SmartApp:
 
 <device or capability preference name>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 
 A reference to the device or devices selected during app installation or update.
 
@@ -133,7 +133,7 @@ A reference to the device or devices selected during app installation or update.
 ----
 
 <number or decimal preference name>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 
 A reference to the value entered for a number or decimal input preference.
 
@@ -160,7 +160,7 @@ A reference to the value entered for a number or decimal input preference.
 ----
 
 <text, mode, or time preference name>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 
 A reference to the value entered for a ``text``, ``mode``, or ``time`` input type.
 
@@ -201,7 +201,7 @@ time        `String`_ - the full date string in the format of “yyyy-MM-dd’T�
 .. _add_child_app:
 
 addChildApp()
-~~~~~~~~~~~~~
+-------------
 
 Adds a child app to a SmartApp.
 
@@ -225,7 +225,7 @@ Adds a child app to a SmartApp.
     :ref:`installed_smart_app_wrapper` - The InstalledSmartAppWrapper instance that represents the child SmartApp that was created.
 
 addChildDevice()
-~~~~~~~~~~~~~~~~
+----------------
 
 Adds a child device to a SmartApp. An example use is in service manager SmartApps.
 
@@ -252,7 +252,7 @@ Adds a child device to a SmartApp. An example use is in service manager SmartApp
 ----
 
 apiServerUrl()
-~~~~~~~~~~~~~~
+--------------
 
 Returns the URL of the server where this SmartApp can be reached for API calls, along with the specified path appended to it. Use this instead of hard-coding a URL to ensure that the correct server URL for this installed instance is returned.
 
@@ -279,7 +279,7 @@ Returns the URL of the server where this SmartApp can be reached for API calls, 
 ----
 
 atomicState
-~~~~~~~~~~~
+-----------
 
 A map of name/value pairs that SmartApp can use to save and retrieve data across SmartApp executions. This is similar to :ref:`smartapp-state`, but will immediately write and read from the backing data store. Prefer using ``state`` over ``atomicState`` when possible.
 
@@ -308,7 +308,7 @@ A map of name/value pairs that SmartApp can use to save and retrieve data across
 .. _smartapp_can_schedule:
 
 canSchedule()
-~~~~~~~~~~~~~
+-------------
 
 Returns true if the SmartApp is able to schedule jobs. Currently SmartApps are limited to 4 scheduled jobs. That limit includes operations such as runIn and runOnce.
 
@@ -329,7 +329,7 @@ Returns true if the SmartApp is able to schedule jobs. Currently SmartApps are l
 .. _smartapp_find_child_app_by_name:
 
 findChildAppByName()
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Returns the first :ref:`installed_smart_app_wrapper` found as a child of this SmartApp that has the specified name.
 
@@ -354,7 +354,7 @@ Returns the first :ref:`installed_smart_app_wrapper` found as a child of this Sm
 ----
 
 getChildApps()
-~~~~~~~~~~~~~~
+--------------
 
 Get all child SmartApps for this SmartApp, if they exist.
 
@@ -367,7 +367,7 @@ Get all child SmartApps for this SmartApp, if they exist.
 ----
 
 deleteChildDevice()
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Deletes the child device with the specified device network id.
 
@@ -386,7 +386,7 @@ Deletes the child device with the specified device network id.
 ----
 
 getAllChildDevices()
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Returns a list of all child devices, including virtual devices. This is a wrapper for ``getChildDevices(true)``.
 
@@ -399,7 +399,7 @@ Returns a list of all child devices, including virtual devices. This is a wrappe
 ----
 
 getApiServerUrl()
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Returns the URL of the server where this SmartApp can be reached for API calls. Use this instead of hard-coding a URL to ensure that the correct server URL for this installed instance is returned.
 
@@ -412,7 +412,7 @@ Returns the URL of the server where this SmartApp can be reached for API calls. 
 ----
 
 getChildDevice()
-~~~~~~~~~~~~~~~~
+----------------
 
 Returns a device based upon the specified device network id. This is mostly used in service manager SmartApps.
 
@@ -428,7 +428,7 @@ Returns a device based upon the specified device network id. This is mostly used
 ----
 
 getChildDevices()
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Returns a list of all child devices. An example use would be in service manager SmartApps.
 
@@ -446,7 +446,7 @@ Returns a list of all child devices. An example use would be in service manager 
 .. _smartapp_get_sunrise_and_sunset:
 
 getSunriseAndSunset()
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 Gets a map containing the local sunrise and sunset times.
 
@@ -491,7 +491,7 @@ Gets a map containing the local sunrise and sunset times.
 ----
 
 getWeatherFeature()
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Calls the Weather Underground API to to return weather forecasts and related data.
 
@@ -518,7 +518,7 @@ Calls the Weather Underground API to to return weather forecasts and related dat
 .. _smartapp_http_delete:
 
 httpDelete()
-~~~~~~~~~~~~
+------------
 
 Executes an HTTP DELETE request and passes control to the specified closure. The closure is passed one `HttpResponseDecorator`_ argument from which the response content and header information can be extracted.
 
@@ -554,7 +554,7 @@ Executes an HTTP DELETE request and passes control to the specified closure. The
 .. _smartapp_http_error:
 
 httpError()
-~~~~~~~~~~~
+-----------
 
 Throws a ``SmartAppException`` with the specified status code and message.
 
@@ -580,7 +580,7 @@ This should be used to send an HTTP error to any calling client.
 .. _smartapp_http_get:
 
 httpGet()
-~~~~~~~~~
+---------
 
 Executes an HTTP GET request and passes control to the specified closure. The closure is passed one `HttpResponseDecorator`_ argument from which the response content and header information can be extracted.
 
@@ -637,7 +637,7 @@ If the response content type is JSON, the response data will automatically be pa
 .. _smartapp_http_head:
 
 httpHead()
-~~~~~~~~~~
+----------
 
 Executes an HTTP HEAD request and passes control to the specified closure. The closure is passed one `HttpResponseDecorator`_ argument from which the response content and header information can be extracted.
 
@@ -670,7 +670,7 @@ Executes an HTTP HEAD request and passes control to the specified closure. The c
 .. _smartapp_http_post:
 
 httpPost()
-~~~~~~~~~~
+----------
 
 Executes an HTTP POST request and passes control to the specified closure. The closure is passed one `HttpResponseDecorator`_ argument from which the response content and header information can be extracted.
 
@@ -721,7 +721,7 @@ If the response content type is JSON, the response data will automatically be pa
 .. _smartapp_http_post_json:
 
 httpPostJson()
-~~~~~~~~~~~~~~
+--------------
 
 Executes an HTTP POST request with a JSON-encoded body and content type, and passes control to the specified closure. The closure is passed one `HttpResponseDecorator`_ argument from which the response content and header information can be extracted.
 
@@ -784,7 +784,7 @@ If the response content type is JSON, the response data will automatically be pa
 .. _smartapp_http_put:
 
 httpPut()
-~~~~~~~~~
+---------
 
 Executes an HTTP PUT request and passes control to the specified closure. The closure is passed one `HttpResponseDecorator`_ argument from which the response content and header information can be extracted.
 
@@ -834,7 +834,7 @@ If the response content type is JSON, the response data will automatically be pa
 .. _smartapp_http_put_json:
 
 httpPutJson()
-~~~~~~~~~~~~~
+-------------
 
 Executes an HTTP PUT request with a JSON-encoded body and content type, and passes control to the specified closure. The closure is passed one `HttpResponseDecorator`_ argument from which the response content and header information can be extracted.
 
@@ -870,13 +870,13 @@ If the response content type is JSON, the response data will automatically be pa
 
 ----
 
-location
-~~~~~~~~
+getLocation()
+-------------
 
 The :ref:`location_ref` into which this SmartApp has been installed.
 
 **Signature:**
-    ``Location location``
+    ``Location getLocation()``
 
 **Returns:**
     :ref:`location_ref` - The Location into which this SmartApp has been installed.
@@ -886,7 +886,7 @@ The :ref:`location_ref` into which this SmartApp has been installed.
 .. _smartapp_now:
 
 now()
-~~~~~
+----
 
 Gets the current Unix time in milliseconds.
 
@@ -899,7 +899,7 @@ Gets the current Unix time in milliseconds.
 ----
 
 parseJson()
-~~~~~~~~~~~
+-----------
 
 Parses the specified string into a JSON data structure.
 
@@ -915,7 +915,7 @@ Parses the specified string into a JSON data structure.
 ----
 
 parseXml()
-~~~~~~~~~~
+----------
 
 Parses the specified string into an XML data structure.
 
@@ -931,7 +931,7 @@ Parses the specified string into an XML data structure.
 ----
 
 parseLanMessage()
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Parses a Base64-encoded LAN message received from the hub into a map with header and body elements, as well as parsing the body into an XML document.
 
@@ -955,7 +955,7 @@ Parses a Base64-encoded LAN message received from the hub into a map with header
 ----
 
 parseSoapMessage()
-~~~~~~~~~~~~~~~~~~
+------------------
 
 Parses a Base64-encoded LAN message received from the hub into a map with header and body elements, as well as parsing the body into an XML document. This method is commonly used to parse `UPNP SOAP <http://www.w3.org/TR/soap12-part1/>`__ messages.
 
@@ -983,7 +983,7 @@ Parses a Base64-encoded LAN message received from the hub into a map with header
 .. _smartapp_render:
 
 render()
-~~~~~~~~
+--------
 
 Returns a HTTP response to the calling client with the options specified.
 
@@ -1022,7 +1022,7 @@ Returns a HTTP response to the calling client with the options specified.
 .. _smartapp_run_in:
 
 runIn()
-~~~~~~~
+-------
 
 Executes a specified ``handlerMethod`` after ``delaySeconds`` have elapsed.
 
@@ -1070,7 +1070,7 @@ Executes a specified ``handlerMethod`` after ``delaySeconds`` have elapsed.
 .. _smartapp_run_every_5_minutes:
 
 runEvery5Minutes()
-~~~~~~~~~~~~~~~~~~
+------------------
 
 Creates a recurring schedule that executes the specified ``handlerMethod`` every five minutes. Using this method will pick a random start time in the next five minutes, and run every five minutes after that.
 
@@ -1116,7 +1116,7 @@ Creates a recurring schedule that executes the specified ``handlerMethod`` every
 .. _smartapp_run_every_10_minutes:
 
 runEvery10Minutes()
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Creates a recurring schedule that executes the specified ``handlerMethod`` every ten minutes. Using this method will pick a random start time in the next ten minutes, and run every ten minutes after that.
 
@@ -1162,7 +1162,7 @@ Creates a recurring schedule that executes the specified ``handlerMethod`` every
 .. _smartapp_run_every_15_minutes:
 
 runEvery15Minutes()
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Creates a recurring schedule that executes the specified ``handlerMethod`` every fifteen minutes. Using this method will pick a random start time in the next five minutes, and run every five minutes after that.
 
@@ -1208,7 +1208,7 @@ Creates a recurring schedule that executes the specified ``handlerMethod`` every
 .. _smartapp_run_every_30_minutes:
 
 runEvery30Minutes()
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Creates a recurring schedule that executes the specified ``handlerMethod`` every thirty minutes. Using this method will pick a random start time in the next thirty minutes, and run every thirty minutes after that.
 
@@ -1254,7 +1254,7 @@ Creates a recurring schedule that executes the specified ``handlerMethod`` every
 .. _smartapp_run_every_1_hours:
 
 runEvery1Hour()
-~~~~~~~~~~~~~~~
+---------------
 
 Creates a recurring schedule that executes the specified ``handlerMethod`` every hour. Using this method will pick a random start time in the next hour, and run every hour after that.
 
@@ -1300,7 +1300,7 @@ Creates a recurring schedule that executes the specified ``handlerMethod`` every
 .. _smartapp_run_every_3_hours:
 
 runEvery3Hours()
-~~~~~~~~~~~~~~~~
+----------------
 
 Creates a recurring schedule that executes the specified ``handlerMethod`` every three hours. Using this method will pick a random start time in the next hour, and run every three hours after that.
 
@@ -1346,7 +1346,7 @@ Creates a recurring schedule that executes the specified ``handlerMethod`` every
 .. _smartapp_run_once:
 
 runOnce()
-~~~~~~~~~
+---------
 
 Executes the ``handlerMethod`` once at the specified date and time.
 
@@ -1386,7 +1386,7 @@ Executes the ``handlerMethod`` once at the specified date and time.
 .. _smartapp_schedule:
 
 schedule()
-~~~~~~~~~~
+----------
 
 Creates a scheduled job that calls the ``handlerMethod`` once per day at the time specified, or according to a cron schedule.
 
@@ -1453,7 +1453,7 @@ Creates a scheduled job that calls the ``handlerMethod`` once per day at the tim
 .. _smartapp_send_event:
 
 sendEvent()
-~~~~~~~~~~~
+-----------
 
 Creates and sends an event constructed from the specified properties. If a device is specified, then a DEVICE event will be created, otherwise an APP event will be created.
 
@@ -1506,7 +1506,7 @@ Creates and sends an event constructed from the specified properties. If a devic
 ----
 
 sendLocationEvent()
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Sends a LOCATION event constructed from the specified properties. See the :ref:`event_ref` reference for a list of available properties. Other SmartApps can receive location events by subscribing to the location. Examples of exisisting location events include sunrise and sunset.
 
@@ -1539,7 +1539,7 @@ Sends a LOCATION event constructed from the specified properties. See the :ref:`
 .. _smartapp_send_notification:
 
 sendNotification()
-~~~~~~~~~~~~~~~~~~
+------------------
 
 Sends the specified message and displays it in the *Hello, Home* portion of the mobile application.
 
@@ -1577,7 +1577,7 @@ Sends the specified message and displays it in the *Hello, Home* portion of the 
 .. _smartapp_send_notification_event:
 
 sendNotificationEvent()
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 Displays a message in *Hello, Home*, but does not send a push notification or SMS message.
 
@@ -1601,7 +1601,7 @@ Displays a message in *Hello, Home*, but does not send a push notification or SM
 .. _smartapp_send_notification_to_contact:
 
 sendNotificationToContacts()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 Sends the specified message to the specified contacts.
 
@@ -1648,7 +1648,7 @@ Sends the specified message to the specified contacts.
 .. _smartapp_send_push:
 
 sendPush()
-~~~~~~~~~~
+----------
 
 Sends the specified message as a push notification to users mobile devices and displays it in *Hello, Home*.
 
@@ -1672,7 +1672,7 @@ Sends the specified message as a push notification to users mobile devices and d
 .. _smartapp_send_push_message:
 
 sendPushMessage()
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Sends the specified message as a push notification to users mobile devices but does not display it in *Hello, Home*.
 
@@ -1696,7 +1696,7 @@ Sends the specified message as a push notification to users mobile devices but d
 .. _smartapp_send_sms:
 
 sendSms()
-~~~~~~~~~
+---------
 
 Sends the message as an SMS message to the specified phone number and displays it in Hello, Home. The message can be no longer than 140 characters.
 
@@ -1722,7 +1722,7 @@ Sends the message as an SMS message to the specified phone number and displays i
 .. _smartapp_send_sms_message:
 
 sendSmsMessage()
-~~~~~~~~~~~~~~~~
+----------------
 
 Sends the message as an SMS message to the specified phone number but does not display it in Hello, Home. The message can be no longer than 140 characters.
 
@@ -1748,7 +1748,7 @@ Sends the message as an SMS message to the specified phone number but does not d
 .. _smartapp_set_location_mode:
 
 setLocationMode()
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Set the mode for this location.
 
@@ -1768,7 +1768,7 @@ Set the mode for this location.
 ----
 
 settings
-~~~~~~~~
+--------
 
 A map of name/value pairs containing all of the installed SmartApp's preferences.
 
@@ -1805,7 +1805,7 @@ A map of name/value pairs containing all of the installed SmartApp's preferences
 .. _smartapp-state:
 
 state
-~~~~~
+-----
 
 A map of name/value pairs that SmartApps can use to save and retrieve data across SmartApp executions.
 
@@ -1836,7 +1836,7 @@ A map of name/value pairs that SmartApps can use to save and retrieve data acros
 ----
 
 stringToMap()
-~~~~~~~~~~~~~
+-------------
 
 Parses a comma-delimited string into a map.
 
@@ -1865,7 +1865,7 @@ Parses a comma-delimited string into a map.
 .. _smartapp_subscribe:
 
 subscribe()
-~~~~~~~~~~~
+-----------
 
 Subscribes to the various events for a device or location. The specified ``handlerMethod`` will be called when the event is fired.
 
@@ -1934,7 +1934,7 @@ All event handler methods will be passed an :ref:`event_ref` that represents the
 .. _smartapp_subscribe_to_command:
 
 subscribeToCommand()
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Subscribes to device commands that are sent to a device. The specified ``handlerMethod`` will be called whenever the specified ``command`` is sent.
 
@@ -1971,7 +1971,7 @@ Subscribes to device commands that are sent to a device. The specified ``handler
 ----
 
 timeOfDayIsBetween()
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Find if a given date is between a lower and upper bound.
 
@@ -2001,7 +2001,7 @@ Find if a given date is between a lower and upper bound.
 ----
 
 timeOffset()
-~~~~~~~~~~~~
+------------
 
 Gets a time offset in milliseconds for the specified input.
 
@@ -2030,7 +2030,7 @@ Gets a time offset in milliseconds for the specified input.
 ----
 
 timeToday()
-~~~~~~~~~~~
+-----------
 
 Gets a `Date`_ object for today's date, for the specified time in the date-time parameter.
 
@@ -2070,7 +2070,7 @@ Gets a `Date`_ object for today's date, for the specified time in the date-time 
 ----
 
 timeTodayAfter()
-~~~~~~~~~~~~~~~~
+----------------
 
 Gets a `Date`_ object for the specified input that is guaranteed to be after the specified starting date.
 
@@ -2115,7 +2115,7 @@ Gets a `Date`_ object for the specified input that is guaranteed to be after the
 ----
 
 timeZone()
-~~~~~~~~~~
+----------
 
 Get a `TimeZone` object for the specified time value entered as a SmartApp preference. This will get the current time zone of the mobile app (not the hub location).
 
@@ -2145,7 +2145,7 @@ Get a `TimeZone` object for the specified time value entered as a SmartApp prefe
 ----
 
 toDateTime()
-~~~~~~~~~~~~
+------------
 
 Get a `Date`_ object for the specified string.
 
@@ -2176,7 +2176,7 @@ Get a `Date`_ object for the specified string.
 .. _smartapp_unschedule:
 
 unschedule()
-~~~~~~~~~~~~
+------------
 
 Deletes all scheduled jobs for the SmartApp.
 If using the optional ``method`` parameter, then it deletes the scheduled job for the specified handler name only.
@@ -2197,7 +2197,7 @@ If using the optional ``method`` parameter, then it deletes the scheduled job fo
 .. _smartapp_unsubscribe:
 
 unsubscribe()
-~~~~~~~~~~~~~
+-------------
 
 Deletes all subscriptions for the installed SmartApp, or for a specific device or devices if specified.
 

--- a/ref-docs/state-ref.rst
+++ b/ref-docs/state-ref.rst
@@ -30,13 +30,13 @@ A few ways to get a State object instance from a device (See the :ref:`device_re
 
 ----
 
-date
-----
+getDate()
+---------
 
 The date and time the State object was created.
 
 **Signature:**
-    ``Date date``
+    ``Date getDate()``
 
 **Returns:**
     `Date`_ - the Date this State object was created.
@@ -49,33 +49,33 @@ The date and time the State object was created.
 
 ----
 
-dateValue
----------
+getDateValue()
+--------------
 
 The value of the underlying attribute as a Date.
 
 **Signature:**
-    ``Date dateValue``
+    ``Date getDateValue()``
 
 **Returns:**
     `Date`_ - the value if the underlying attribute as a Date. Returns ``null`` if the attribute value cannot be parsed into a Date.
 
 ----
 
-doubleValue
------------
+getDoubleValue()
+----------------
 
 The value of the underlying Attribute as a Double.
 
 **Signature:**
-    ``Double doubleValue``
+    ``Double getDoubleValue()``
 
 **Returns:**
     `Double`_ - the value of the underlying attribute as a Double.
 
 .. warning::
 
-    ``doubleValue`` throws an Exception if the underlying attribute value cannot be parsed into a Double.
+    ``getDoubleValue()`` throws an Exception if the underlying attribute value cannot be parsed into a Double.
 
     You should wrap calls in a try/catch block.
 
@@ -92,20 +92,20 @@ The value of the underlying Attribute as a Double.
 
 ----
 
-floatValue
-----------
+getFloatValue()
+---------------
 
 The value of the underlying Attribute as a Float.
 
 **Signature:**
-    ``Float floatValue``
+    ``Float getFloatValue()``
 
 **Returns:**
     `Float`_ - the value of the underlying Attribute as a Float.
 
 .. warning::
 
-    ``doubleValue`` throws an Exception if the underlying attribute value cannot be parsed into a Double.
+    ``getFloatValue()`` throws an Exception if the underlying attribute value cannot be parsed into a Double.
 
     You should wrap calls in a try/catch block.
 
@@ -122,13 +122,13 @@ The value of the underlying Attribute as a Float.
 
 ----
 
-id
---
+getId()
+-------
 
 The unique system identifier for the State object.
 
 **Signature:**
-    ``String id``
+    ``String getId()``
 
 **Returns:**
     `String`_ - the unique system identifer for the State object.
@@ -142,20 +142,20 @@ The unique system identifier for the State object.
 
 ----
 
-integerValue
-------------
+getIntegerValue()
+-----------------
 
 The value of the underlying Attribute as an Integer.
 
 **Signature:**
-    ``Integer floatValue``
+    ``Integer getIntegerValue()``
 
 **Returns:**
     `Integer`_ - the value of the underlying Attribute as a Integer.
 
 .. warning::
 
-    ``integerValue`` throws an Exception if the underlying attribute value cannot be parsed into a Integer.
+    ``getIntegerValue()`` throws an Exception if the underlying attribute value cannot be parsed into a Integer.
 
     You should wrap calls in a try/catch block.
 
@@ -173,13 +173,13 @@ The value of the underlying Attribute as an Integer.
 
 ----
 
-isoDate
--------
+getIsoDate()
+------------
 
 The acquisition time of this State object as an ISO-8601 String
 
 **Signature:**
-    ``String isoDate``
+    ``String getIsoDate()``
 
 **Returns:**
     `String`_ - the time this Sate object was created as an ISO-8601 Strring
@@ -193,20 +193,20 @@ The acquisition time of this State object as an ISO-8601 String
 
 ----
 
-jsonValue
----------
+getJsonValue()
+--------------
 
 Value of the underlying Attribute parsed into a JSON data structure.
 
 **Signature:**
-    ``Object jsonValue``
+    ``Object getJsonValue()``
 
 **Returns:**
     `Object`_ - the value if the underlying Attribute parsed into a JSON data structure.
 
 .. warning::
 
-    ``jsonValue`` throws an Exception of the underlying attribute value cannot be parsed into a Integer.
+    ``getJsonValue()`` throws an Exception of the underlying attribute value cannot be parsed into a Integer.
 
     You should wrap calls in a try/catch block.
 
@@ -223,20 +223,20 @@ Value of the underlying Attribute parsed into a JSON data structure.
 
 ----
 
-longValue
----------
+getLongValue()
+--------------
 
 The value of the underlying Attribute as a Long.
 
 **Signature:**
-    ``Long longValue``
+    ``Long getLongValue()``
 
 **Returns:**
     `Long`_ - the value if the underlying Attribute as a Long.
 
 .. warning::
 
-    ``longValue`` throws an Exception of the underlying attribute value cannot be parsed into a Long.
+    ``getLongValue()`` throws an Exception of the underlying attribute value cannot be parsed into a Long.
 
     You should wrap calls in a try/catch block.
 
@@ -254,13 +254,13 @@ The value of the underlying Attribute as a Long.
 
 ----
 
-name
-----
+getName()
+---------
 
 The name of the underlying Attribute.
 
 **Signature:**
-    ``String name``
+    ``String getName()``
 
 **Returns:**
     `String`_ - the name of the underlying Attribute.
@@ -274,20 +274,20 @@ The name of the underlying Attribute.
 
 ----
 
-numberValue
------------
+getNumberValue()
+----------------
 
 The value of the underlying Attribute as a BigDecimal.
 
 **Signature:**
-    ``BigDecimal numberValue``
+    ``BigDecimal getNumberValue()``
 
 **Returns:**
-    `BigDecimal`_ - the value if the underlying Attribute as a BigDecimal.
+    `Number`_ - the value if the underlying Attribute as a Number.
 
 .. warning::
 
-    ``numberValue`` throws an Exception of the underlying attribute value cannot be parsed into a BigDecimal.
+    ``getNumberValue()`` throws an Exception of the underlying attribute value cannot be parsed into a getNumberValue().
 
     You should wrap calls in a try/catch block.
 
@@ -304,20 +304,20 @@ The value of the underlying Attribute as a BigDecimal.
 
 ----
 
-numericValue
-------------
+getNumericValue()
+-----------------
 
-The value of the underlying Attribute as a BigDecimal.
+The value of the underlying Attribute as a Number.
 
 **Signature:**
-    ``BigDecimal numericValue``
+    ``Number getNumericValue()``
 
 **Returns:**
-    `BigDecimal`_ - the value if the underlying Attribute as a BigDecimal.
+    `Number`_ - the value if the underlying Attribute as a Number.
 
 .. warning::
 
-    ``numericValue`` throws an Exception of the underlying attribute value cannot be parsed into a BigDecimal.
+    ``getNumericValue()`` throws an Exception of the underlying attribute value cannot be parsed into a Number.
 
     You should wrap calls in a try/catch block.
 
@@ -334,13 +334,13 @@ The value of the underlying Attribute as a BigDecimal.
 
 ----
 
-stringValue
------------
+getStringValue()
+----------------
 
 The value of the underlying Attribute as a String
 
 **Signature:**
-    ``String stringValue``
+    ``String getStringValue()``
 
 **Returns:**
     `String`_ - the value of the underlying Attribute as a String.
@@ -354,13 +354,13 @@ The value of the underlying Attribute as a String
 
 ----
 
-unit
-----
+getUnit()
+---------
 
 The unit of measure for the underlying Attribute.
 
 **Signature:**
-    ``String unit``
+    ``String getUnit()``
 
 **Returns:**
     `String`_ - the unit of measure for the underlying Attribute, if applicable, ``null`` otherwise.
@@ -374,13 +374,13 @@ The unit of measure for the underlying Attribute.
 
 ----
 
-value
------
+getValue()
+----------
 
 The value of the underlying Attribute as a String
 
 **Signature:**
-    ``String value``
+    ``String getUnit()``
 
 **Returns:**
     `String`_ - the value of the underlying Attribute as a String.
@@ -394,8 +394,8 @@ The value of the underlying Attribute as a String
 
 ----
 
-xyzValue
---------
+getXyzValue()
+-------------
 
 Value of the underlying Attribute as a 3-entry Map with keys 'x', 'y', and 'z' with BigDecimal values. For example:
 
@@ -406,7 +406,7 @@ Value of the underlying Attribute as a 3-entry Map with keys 'x', 'y', and 'z' w
 Typically only useful for getting position data from the "Three Axis" Capability.
 
 **Signature:**
-    ``Map<String, BigDecimal> xyzValue``
+    ``Map<String, BigDecimal> getXyzValue()``
 
 **Returns:**
     `Map`_ < `String`_ , `BigDecimal`_ > - A map representing the X, Y, and Z coordinates.
@@ -432,7 +432,7 @@ Typically only useful for getting position data from the "Three Axis" Capability
     } catch (e) {
         log.debug "Trying to get the xyzValue threw an exception: $e"
     }
-    
+
 
 .. _BigDecimal: http://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html
 .. _Boolean: http://docs.oracle.com/javase/7/docs/api/java/lang/Boolean.html


### PR DESCRIPTION
In anticipation of the updated `getChildApps()` method, it increasingly seems confusing that we document our getters using the Groovy property syntax shortcut. Presenting them as properties also causes confusion because it can lead developers to think that they can set the values as well (which they can't). 

@unixbeast you should review this please.

/cc @rajkaramchedu as you look at the Time story if you make updates to the reference docs you'll want to get this change (once merged) and follow the same pattern.