### PR TITLE
[DOCS-344] - add docs for getAllChildApps() methods and their derivatives

### DIFF
--- a/ref-docs/installed-smart-app-wrapper-ref.rst
+++ b/ref-docs/installed-smart-app-wrapper-ref.rst
@@ -35,6 +35,27 @@ Gets the current state of the given attribute.
 
 ----
 
+getAllChildApps()
+-----------------
+
+Gets a list of child SmartApps associated with this SmartApp.
+This includes both "complete" and "incomplete" child SmartApp installs.
+
+**Signature:**
+    ``List<InstalledSmartApp> getAllChildApps()``
+
+**Returns:**
+    `List`_ < :ref:`installed_smart_app_wrapper` > - A list of child SmartApps
+
+**Example:**
+
+.. code-block:: groovy
+
+    def childApps = app.getAllChildApps()
+    log.debug "The app has ${childApps.size()} child SmartApps"
+
+----
+
 getAppSettings()
 ----------------
 
@@ -55,6 +76,7 @@ getChildApps()
 --------------
 
 Gets a list of child apps associated with this SmartApp.
+This only returns child apps that have an installation state of "complete".
 
 **Signature:**
     ``List<InstalledSmartApp> getChildApps()``

--- a/ref-docs/installed-smart-app-wrapper-ref.rst
+++ b/ref-docs/installed-smart-app-wrapper-ref.rst
@@ -42,7 +42,7 @@ Gets a list of child SmartApps associated with this SmartApp.
 This includes both "complete" and "incomplete" child SmartApp installs.
 
 **Signature:**
-    ``List<InstalledSmartApp> getAllChildApps()``
+    ``def getAllChildApps()``
 
 **Returns:**
     `List`_ < :ref:`installed_smart_app_wrapper` > - A list of child SmartApps
@@ -79,7 +79,7 @@ Gets a list of child apps associated with this SmartApp.
 This only returns child apps that have an installation state of "complete".
 
 **Signature:**
-    ``List<InstalledSmartApp> getChildApps()``
+    ``def getChildApps()``
 
 **Returns:**
     `List`_ < :ref:`installed_smart_app_wrapper` > - A list of child SmartApps

--- a/ref-docs/smartapp-ref.rst
+++ b/ref-docs/smartapp-ref.rst
@@ -326,16 +326,66 @@ Returns true if the SmartApp is able to schedule jobs. Currently SmartApps are l
 
 ----
 
+findAllChildAppsByName()
+------------------------
+
+Finds all child SmartApps matching the specified name.
+This includes both "complete" and "incomplete" child SmartApp installs.
+
+**Signature:**
+    ``List<InstalledSmartApp> findAllChildAppsByName(String namespace, String name)``
+
+**Parameters:**
+    `String`_ ``name`` - the name of the SmartApp to find.
+
+**Returns:**
+    A list of :ref:`installed_smart_app_wrapper`, or an empty list if none are found.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def children = findAllChildAppsByName(My Child App")
+    log.debug "found ${children.size()} child apps"
+
+----
+
+findAllChildAppsByNamespaceAndName()
+------------------------------------
+
+Finds all child SmartApps matching the specified namespace and name.
+This includes both "complete" and "incomplete" child SmartApp installs.
+
+**Signature:**
+    ``List<InstalledSmartApp> findAllChildAppsByNamespaceAndName(String namespace, String name)``
+
+**Parameters:**
+    `String`_ ``namespace`` - the namespace of the SmartApp to find.
+
+    `String`_ ``name`` - the name of the SmartApp to find.
+
+**Returns:**
+    A list of :ref:`installed_smart_app_wrapper`, or an empty list if none are found.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def children = findAllChildAppsByNamespaceAndName("somenamespace", "My Child App")
+    log.debug "found ${children.size()} child apps"
+
+----
+
 .. _smartapp_find_child_app_by_name:
 
 findChildAppByName()
 --------------------
 
-Returns the first :ref:`installed_smart_app_wrapper` found as a child of this SmartApp that has the specified name.
-
+Finds a child SmartApp matching the specified name.
+This includes both "complete" and "incomplete" child SmartApp installs.
 
 **Signature:**
-    ``InstalledSmartApp findChildAppByName(String appName)``
+    ``def findChildAppByName(String appName)``
 
 **Parameters:**
     `String`_ ``appName`` - the name of the SmartApp to find.
@@ -353,16 +403,78 @@ Returns the first :ref:`installed_smart_app_wrapper` found as a child of this Sm
 
 ----
 
+findChildAppByNamespaceAndName()
+--------------------------------
+
+Finds a child SmartApp matching the specified namespace and name.
+This includes both "complete" and "incomplete" child SmartApp installs.
+
+**Signature:**
+    ``def findChildAppsByNamespaceAndName(String namespace, String name)``
+
+**Parameters:**
+    `String`_ ``namespace`` - the namespace of the SmartApp to find.
+
+    `String`_ ``name`` - the name of the SmartApp to find.
+
+**Returns:**
+    A :ref:`installed_smart_app_wrapper`, or null if no child app is found.
+    If multiple child apps are found that match the namespace and name, the first one will be returned.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def child = findChildAppsByNamespaceAndName("somenamespace", "My Child App")
+    log.debug "child app id: ${child.id}"
+
+----
+
+getAllChildApps()
+-----------------
+
+Gets a list of child apps associated with this SmartApp.
+This includes both "complete" and "incomplete" child SmartApp installs.
+
+**Signature:**
+    ``List<InstalledSmartApp> getAllChildApps()``
+
+**Returns:**
+    `List`_ < :ref:`installed_smart_app_wrapper` > - A list of child SmartApps
+
+**Example:**
+
+.. code-block:: groovy
+
+    def childApps = app.getAllChildApps()
+    log.debug "This app has ${childApps.size()} child apps"
+
+----
+
 getChildApps()
 --------------
 
-Get all child SmartApps for this SmartApp, if they exist.
+Gets a list of child apps associated with this SmartApp.
+This only returns child apps that have an installation state of "complete".
 
 **Signature:**
-    ``List getChildApps()``
+    ``List<InstalledSmartApp> getChildApps()``
 
 **Returns:**
-    A list of all the child SmartApps for th is SmartApp, if they exist.
+    `List`_ < :ref:`installed_smart_app_wrapper` > - A list of child SmartApps
+
+**Example:**
+
+.. code-block:: groovy
+
+    def childApps = getChildApps()
+
+    // Update the label for all child apps
+    childApps.each {
+        if (!it.label?.startsWith(app.name)) {
+            it.updateLabel("$app.name/$it.label")
+        }
+    }
 
 ----
 

--- a/ref-docs/smartapp-ref.rst
+++ b/ref-docs/smartapp-ref.rst
@@ -345,7 +345,7 @@ This includes both "complete" and "incomplete" child SmartApp installs.
 
 .. code-block:: groovy
 
-    def children = findAllChildAppsByName(My Child App")
+    def children = findAllChildAppsByName("My Child App")
     log.debug "found ${children.size()} child apps"
 
 ----
@@ -425,8 +425,8 @@ This includes both "complete" and "incomplete" child SmartApp installs.
 
 .. code-block:: groovy
 
-    def child = findChildAppsByNamespaceAndName("somenamespace", "My Child App")
-    log.debug "child app id: ${child.id}"
+    def child = findChildAppByNamespaceAndName("somenamespace", "My Child App")
+    log.debug "child app id: ${child?.id}"
 
 ----
 

--- a/ref-docs/smartapp-ref.rst
+++ b/ref-docs/smartapp-ref.rst
@@ -399,7 +399,7 @@ This includes both "complete" and "incomplete" child SmartApp installs.
 .. code-block:: groovy
 
     def child = findChildAppByName("My Child App")
-    log.debug "child app id: ${child.id}"
+    log.debug "child app id: ${child?.id}"
 
 ----
 


### PR DESCRIPTION
Document the following methods, including which return complete and incomplete installations, versus those that only return complete installs:

* `getAllChildApps()` (on SmartApp)
* `findAllChildAppsByName()` (on InstalledSmartAppWrapper)
* `findAllChildAppsByNamespaceAndName()` (on InstalledSmartAppWrapper)
* `findChildAppByNamespaceAndName()` (on InstalledSmartAppWrapper)
* `getAllChildApps()` (on InstalledSmartAppWrapper)

Also clarify that `getChildApps()` will now only return complete child SmartApp installs.

@chrisfsmith please review, thanks!