### PR TITLE
[DOCS-361] document manufacturer and model name on device

### DIFF
--- a/device-type-developers-guide/definition-metadata.rst
+++ b/device-type-developers-guide/definition-metadata.rst
@@ -126,12 +126,12 @@ This process is known as a "join" process, or "fingerprinting".
 
 The fingerprinting process is dependent on the type of device you are looking to pair.
 SmartThings attempts to match devices coming in based on the input and output clusters a device uses, as well as a profileId (for ZigBee) or deviceId (for Z-Wave).
-Basically, by determining what capabilities your device has, SmartThings determines what your device is.
+By determining what capabilities the device has, SmartThings determines what your device is.
 
 
 .. _zigbee-fingerprinting-label:
 
-ZigBee Fingerprinting
+ZigBee fingerprinting
 ^^^^^^^^^^^^^^^^^^^^^
 
 For ZigBee devices, the main profileIds you will need to use are
@@ -149,7 +149,7 @@ An example of a ZigBee fingerprint definition:
         fingerprint profileId: "C05E", inClusters: "0000,0003,0004,0005,0006,0008,0300,1000", outClusters: "0019"
 
 
-Z-Wave Fingerprinting
+Z-Wave fingerprinting
 ^^^^^^^^^^^^^^^^^^^^^
 
 For Z-Wave devices, the fingerprint should include the deviceId of the device and the command classes it supports in the inClusters list.
@@ -183,39 +183,29 @@ The fingerprint will be:
 Note that the fingerprint clusters lists are comma separated while the raw
 description is not.
 
-Fingerprinting Best Practices and Important Information
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _device_handler_fingerprinting_best_practices:
 
-Include Manufacturer and Model
+Fingerprinting best practices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Include manufacturer and model
 ++++++++++++++++++++++++++++++
 
-Try and include the manufacturer and model name to your fingerprint (only supported for ZigBee devices right now - you can add them to Z-Wave devices as well, but they won't be used yet):
+Include the manufacturer and model name in the fingerprint:
 
 .. code-block:: groovy
 
     fingerprint inClusters: "0000,0001,0003,0020,0406,0500", manufacturer: "NYCE", model: "3014"
 
-When adding the manufacturer model and name, you'll likely need to add the following raw commands in the ``refresh()`` command.
-This is used to report back the manufacturer/model name from the device.
-
-The reply will be hexadecimal that you can convert to ascii using the hex-to-ascii converter (we'll be adding a utility method to do this, but in the meantime you can use an online converter like `this one <http://www.rapidtables.com/convert/number/hex-to-ascii.htm>`__):
-
-.. code-block:: groovy
-
-    def refresh() {
-        "st rattr 0x${zigbee.deviceNetworkId} 0x${zigbee.endpointId} 0 4", "delay 200",
-        "st rattr 0x${zigbee.deviceNetworkId} 0x${zigbee.endpointId} 0 5"
-    }
-
-Adding Multiple Fingerprints
-++++++++++++++++++++++++++++
+Add multiple fingerprints
++++++++++++++++++++++++++
 
 You can have multiple fingerprints.
-This is often desirable when a Device Handler should work with multiple versions of a device.
+This is often necessary when a Device Handler should work with multiple versions of a device.
 
 The platform will use the fingerprint with the longest possible match.
 
-Device Pairing Process
+Device pairing process
 ++++++++++++++++++++++
 
 The order of the ``inClusters`` and ``outClusters`` lists is not important to the pairing process.

--- a/ref-docs/device-ref.rst
+++ b/ref-docs/device-ref.rst
@@ -259,170 +259,6 @@ Gets the latest reported values of the specified attribute.
 
 ----
 
-getCapabilities()
------------------
-
-The List of Capabilities provided by this Device.
-
-**Signature:**
-    ``List<Capability> getCapabilities()``
-
-**Returns:**
-    `List`_ <:ref:`capability_ref`> - a List of Capabilities supported by this Device.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def supportedCaps = somedevice.capabilities
-    supportedCaps.each {cap ->
-        log.debug "This device supports the ${cap.name} capability"
-    }
-
-----
-
-getDisplayName()
-----------------
-
-The label of the Device assigned by the user.
-
-**Signature:**
-    ``String getDisplayName()``
-
-**Returns:**
-    `String`_ - the label of the Device assigned by the user, ``null`` if no label iset.
-
-**Example:**
-
-.. code-block:: groovy
-
-    def devLabel = somedevice.displayName
-    if (devLabel) {
-        log.debug "label set by user: $devLabel"
-    } else {
-        log.debug "no label set by user for this device"
-    }
-
-----
-
-getHub()
---------
-
-The Hub associated with this Device.
-
-**Signature:**
-    ``Hub getHub()``
-
-**Returns:**
-    :ref:`hub_ref` - the Hub for this Device.
-
-**Example:**
-
-.. code-block:: groovy
-
-    log.debug "Hub: ${someDevice.hub.name}"
-
-----
-
-getId()
--------
-
-The unique system identifier for this Device.
-
-**Signature:**
-    ``String getId()``
-
-**Returns:**
-    `String`_ - the unique system identifer for this Device.
-
-----
-
-getLabel()
-----------
-
-The name of the Device set by the user in the mobile application or Web IDE.
-
-**Signature:**
-    ``String getLabel()``
-
-**Returns:**
-    `String`_ - the name of the Device as configured by the user.
-
-----
-
-getName()
----------
-
-The internal name of the Device. Typically assigned by the system and editable only by a user in the IDE.
-
-**Signature:**
-    ``String getName()``
-
-**Returns:**
-    `String`_ - the internal name of the Device.
-
-----
-
-.. _supportedAttributes:
-
-getSupportedAttributes()
-------------------------
-
-The list of :ref:`attribute_ref` s for this Device.
-
-**Signature:**
-    ``List<Attribute> getSupportedAttributes()``
-
-**Returns:**
-    `List`_ <:ref:`attribute_ref`> - the list of Attributes for this Device. Includes both capability attributes as well as Device-specific attributes.
-
-**Example:**
-
-.. code-block:: groovy
-
-    preferences {
-        section() {
-            input "theswitch", "capability.switch"
-        }
-    }
-    ...
-    def theAtts = theswitch.supportedAttributes
-    theAtts.each {att ->
-        log.debug "Supported Attribute: ${att.name}"
-    }
-    ...
-
-----
-
-getSupportedCommands()
-----------------------
-
-The list of :ref:`command_ref` s for this Device.
-
-**Signature:**
-    ``List<Command> getSupportedCommands()``
-
-**Returns:**
-    `List`_ <:ref:`command_ref`> - the list of Commands for this Device. Includes both capability commands as well as Device-specific commands.
-
-**Example:**
-
-.. code-block:: groovy
-
-    preferences {
-        section() {
-            input "theswitch", "capability.switch"
-        }
-    }
-    ...
-    def theCommands = theswitch.supportedCommands
-    theCommands.each {com ->
-        log.debug "Supported Command: ${com.name}"
-    }
-    ...
-
-----
-
 events()
 --------
 
@@ -534,6 +370,234 @@ Get a list of Events since the specified date.
 
     def eventsSinceYesterday = somedevice.eventsSince(new Date() - 1)
     log.debug "there have been ${eventsSinceYesterday.size()} since yesterday"
+
+----
+
+getCapabilities()
+-----------------
+
+The List of Capabilities provided by this Device.
+
+**Signature:**
+    ``List<Capability> getCapabilities()``
+
+**Returns:**
+    `List`_ <:ref:`capability_ref`> - a List of Capabilities supported by this Device.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def supportedCaps = somedevice.capabilities
+    supportedCaps.each {cap ->
+        log.debug "This device supports the ${cap.name} capability"
+    }
+
+----
+
+getDisplayName()
+----------------
+
+The label of the Device assigned by the user.
+
+**Signature:**
+    ``String getDisplayName()``
+
+**Returns:**
+    `String`_ - the label of the Device assigned by the user, ``null`` if no label iset.
+
+**Example:**
+
+.. code-block:: groovy
+
+    def devLabel = somedevice.displayName
+    if (devLabel) {
+        log.debug "label set by user: $devLabel"
+    } else {
+        log.debug "no label set by user for this device"
+    }
+
+----
+
+getHub()
+--------
+
+The Hub associated with this Device.
+
+**Signature:**
+    ``Hub getHub()``
+
+**Returns:**
+    :ref:`hub_ref` - the Hub for this Device.
+
+**Example:**
+
+.. code-block:: groovy
+
+    log.debug "Hub: ${someDevice.hub.name}"
+
+----
+
+getId()
+-------
+
+The unique system identifier for this Device.
+
+**Signature:**
+    ``String getId()``
+
+**Returns:**
+    `String`_ - the unique system identifer for this Device.
+
+----
+
+getLabel()
+----------
+
+The name of the Device set by the user in the mobile application or Web IDE.
+
+**Signature:**
+    ``String getLabel()``
+
+**Returns:**
+    `String`_ - the name of the Device as configured by the user.
+
+----
+
+.. _device_ref_manufacturer_name:
+
+getManufacturerName()
+---------------------
+
+Gets the manufacturer name of the device, as specified in the Device Handler's :ref:`fingerprint <device_handler_fingerprinting_best_practices>`.
+If the device was joined using a generic fingerprint, it is whatever the device reported while joining.
+
+Not applicable for cloud or LAN-connected devices (``null`` will be returned).
+
+**Signature:**
+    ``String getManufacturerName()``
+
+**Returns:**
+    `String`_ - the manufacturer name of the device, or ``null``.
+
+**Example:**
+
+.. code-block:: groovy
+
+    preferences {
+        input "switches", "capability.switch", multiple: true
+    }
+
+    def installed() {
+        switches.each {
+            log.debug "switch id: ${it.id}, manufacturer name: ${it.getManufacturerName()}"
+        }
+    }
+
+----
+
+.. _device_ref_model_name:
+
+getModelName()
+--------------
+
+Gets the model name of the device, as specified in the Device Handler's :ref:`fingerprint <device_handler_fingerprinting_best_practices>`.
+If the device was joined using a generic fingerprint, it is whatever the device reported while joining.
+
+Not applicable for cloud or LAN-connected devices (``null`` will be returned).
+
+**Signature:**
+    ``String getModelName()``
+
+**Returns:**
+    `String`_ - the model name of the device, or ``null``.
+
+**Example:**
+
+.. code-block:: groovy
+
+    preferences {
+        input "switches", "capability.switch", multiple: true
+    }
+
+    def installed() {
+        switches.each {
+            log.debug "switch id: ${it.id}, model name: ${it.getModelName()}"
+        }
+    }
+
+----
+
+getName()
+---------
+
+The internal name of the Device. Typically assigned by the system and editable only by a user in the IDE.
+
+**Signature:**
+    ``String getName()``
+
+**Returns:**
+    `String`_ - the internal name of the Device.
+
+----
+
+.. _supportedAttributes:
+
+getSupportedAttributes()
+------------------------
+
+The list of :ref:`attribute_ref` s for this Device.
+
+**Signature:**
+    ``List<Attribute> getSupportedAttributes()``
+
+**Returns:**
+    `List`_ <:ref:`attribute_ref`> - the list of Attributes for this Device. Includes both capability attributes as well as Device-specific attributes.
+
+**Example:**
+
+.. code-block:: groovy
+
+    preferences {
+        section() {
+            input "theswitch", "capability.switch"
+        }
+    }
+    ...
+    def theAtts = theswitch.supportedAttributes
+    theAtts.each {att ->
+        log.debug "Supported Attribute: ${att.name}"
+    }
+    ...
+
+----
+
+getSupportedCommands()
+----------------------
+
+The list of :ref:`command_ref` s for this Device.
+
+**Signature:**
+    ``List<Command> getSupportedCommands()``
+
+**Returns:**
+    `List`_ <:ref:`command_ref`> - the list of Commands for this Device. Includes both capability commands as well as Device-specific commands.
+
+**Example:**
+
+.. code-block:: groovy
+
+    preferences {
+        section() {
+            input "theswitch", "capability.switch"
+        }
+    }
+    ...
+    def theCommands = theswitch.supportedCommands
+    theCommands.each {com ->
+        log.debug "Supported Command: ${com.name}"
+    }
+    ...
 
 ----
 


### PR DESCRIPTION
@workingmonk please review

In `device-ref.rst` there are some organizational changes that don't change content. The only change to look at there is the documentation for `getManufacturerName()` and `getModelName()`.