### PR TITLE
[DOCS-396] styles consistent with developer.smartthings.com

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -14,10 +14,31 @@ body {
     font-family: "Swiss 721 Light" !important;
 }
 
-h1, h2, .rst-content p.caption, h3, h4, h5, h6, legend {
+h1, h2, .rst-content p.caption, h3, h4, h5, h6, legend, input[type="text"] {
     font-family: "Swiss 721 Light" !important;
 }
 
+.wy-side-nav-search, .wy-nav-top {
+    /* background-color: #06abab !important; */
+    background: #06abab;
+    background: -webkit-gradient(left top, right top, color-stop(0%, #06abab), color-stop(51%, #1197b5), color-stop(71%, #1197b5), color-stop(100%, #068ab6));
+    background: -webkit-linear-gradient(left, #06abab 0%, #1197b5 51%, #1197b5 71%, #068ab6 100%);
+    background: linear-gradient(to right, #06abab 0%, #1197b5 51%, #1197b5 71%, #068ab6 100%);
+}
+
+.wy-nav-side {
+    background: #3f3e43 !important;
+}
+
+.wy-menu-vertical p.caption {
+    font-size: 90% !important;
+    color: #ece8e9 !important;
+    padding: 0 0.75em; !important;
+}
+
+.codeblock, pre.literal-block, .rst-content .literal-block, .rst-content pre.literal-block, div[class^='highlight'] {
+    border-radius: 10px !important;
+}
 /* override table width restrictions */
 .wy-table-responsive table td, .wy-table-responsive table th {
     /* !important prevents the common CSS stylesheets from

--- a/conf.py
+++ b/conf.py
@@ -96,7 +96,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'SmartThings Documentation'
+project = u'SmartThings Developer Documentation'
 copyright = u'2016, SmartThings'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -138,7 +138,8 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+#pygments_style = 'sphinx'
+pygments_style = 'monokai'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []

--- a/index.rst
+++ b/index.rst
@@ -29,11 +29,6 @@ Contents
 --------
 
 .. toctree::
-   :maxdepth: 1
-
-   docs-change-log
-
-.. toctree::
    :caption: Getting Started
    :maxdepth: 2
 
@@ -57,8 +52,6 @@ Contents
    arduino/index
    ratelimits/index
    code-review-guidelines
-   contributing/index
-   sept-2015-faq
 
 .. toctree::
     :maxdepth: 1
@@ -66,3 +59,11 @@ Contents
 
     capabilities-reference
     ref-docs/reference
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Misc
+
+   sept-2015-faq
+   docs-change-log
+   contributing/index


### PR DESCRIPTION
Some minor styling improvements:

- nav search area color gradient to be consistent with developers.smartthings.com
- more prominent font size and color for the captions in the nav tree
- consistent font for search text

I also reorganized the toc just a little to tighten things up in the nav tree.

Since overriding styles like this isn't ideal, I've created DOCS-397 to create our own sphinx theme (can just be a fork of the current RTD theme with our modifications to start).

