### PR TITLE
WIP - use monkai dark theme for code blocks

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -38,7 +38,25 @@ h1, h2, .rst-content p.caption, h3, h4, h5, h6, legend, input[type="text"] {
 
 .codeblock, pre.literal-block, .rst-content .literal-block, .rst-content pre.literal-block, div[class^='highlight'] {
     border-radius: 10px !important;
+    background: #3f3e43;
 }
+
+div[class^='highlight'] pre {
+    font-size: 13px;
+}
+
+.highlight-http pre,
+.highlight-json pre,
+.highlight-bash pre,
+.highlight-python pre,
+.highlight-rst pre {
+    color: #fff !important;
+}
+
+.linenodiv pre {
+    color: #fff !important;
+}
+
 /* override table width restrictions */
 .wy-table-responsive table td, .wy-table-responsive table th {
     /* !important prevents the common CSS stylesheets from

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,5 @@
+{# layout.html #}
+{# Import the theme's layout. #}
+{% extends "!layout.html" %}
+
+{% set css_files = css_files + ['_static/pygments.css'] %}

--- a/code-review-guidelines.rst
+++ b/code-review-guidelines.rst
@@ -369,8 +369,9 @@ The best practice is to subscribe explicitly to the attribute:
 
 .. code-block:: groovy
 
-    subscribe(contact1, “contact.open”, myContactHandler)
+    subscribe(contact1, "contact.open", myContactHandler)
 
+    
 However, if the SmartApp must subscribe to a variable (from state, for instance), the reviewer should be able to trace how the variable is set and what the expected attribute will be.
 
 Subscriptions should be specific

--- a/conf.py
+++ b/conf.py
@@ -138,7 +138,7 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'monokai'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
@@ -158,7 +158,7 @@ html_theme = 'default'
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'sticky_navigation': True
+    'sticky_navigation': False
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/contributing/style-guide.rst
+++ b/contributing/style-guide.rst
@@ -120,7 +120,7 @@ It requires placing a label above a section, title, or image:
 
 Another document can then link to ``Some Section`` like this:
 
-.. code-block:: groovy
+.. code-block:: rst
 
     See :ref:`section_label` for more information.
 

--- a/getting-started/groovy-basics.rst
+++ b/getting-started/groovy-basics.rst
@@ -444,13 +444,13 @@ Getters and Setters
 Groovy adds in some convenience JavaBean style getter and setter methods.
 It's worth being aware of this in case you see some code that references a property that seemingly isn't defined anywhere:
 
-    .. code-block:: groovy
+.. code-block:: groovy
 
-        def getSomeValue() {
-            return "got it"
-        }
+    def getSomeValue() {
+        return "got it"
+    }
 
-        assert "got it" == someValue
+    assert "got it" == someValue
 
 How did referencing ``someValue`` end up invoking the method ``getSomeValue()``?
 When Groovy sees a reference to the property named ``someValue``, it first looks to see if it is defined somewhere.

--- a/tools-and-ide/logging.rst
+++ b/tools-and-ide/logging.rst
@@ -60,7 +60,7 @@ Consider the following example that simply forces a ``NullPointerException`` by 
 
 Executing the above code would result in the following message in Live Logging:
 
-.. code-block:: groovy
+.. code-block:: bash
 
     12:42:03 PM: debug caught exception java.lang.NullPointerException: Cannot invoke method boom() on null object @ line 47
 


### PR DESCRIPTION
I'd like some eyes on this and opinions. 

Exploring using the monokai dark theme for code blocks. I have not gone through every page to make sure it will all render ok, but I'm more interested in opinions on the look & feel. 

Here's what a sample code block would look like with these changes:

![monokai_code_blocks](https://cloud.githubusercontent.com/assets/276225/20202844/1a7b884c-a788-11e6-841b-570e37755561.png)

DM me on slack if you'd like to see a live demo site with these changes.

@unixbeast @rajkaramchedu @tslagle13 @mrnohr interested in your opinions.