### PR TITLE
DOCS-415 correcting some issues with template

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -35,7 +35,7 @@ properties = {}
 # Read in the capability XML and properties files.
 path = '_static/capabilities'
 for dirpath, dirs, files in os.walk(path):
-    for filename in files:
+    for filename in sorted(files):
         if filename.endswith('.xml'):
             # If we have a XML file, read and parse it into and element tree
             # structure. Then use xmltodict to convert the XML structure into a

--- a/test.rst
+++ b/test.rst
@@ -34,10 +34,6 @@ Capabilities Reference
         The name of the capability that is used by a Device Handler.
     Preferences Reference:
         The string you would use in a SmartApp to allow a user to select from devices supporting this capability.
-    Attributes:
-        The attributes that the capability defines.
-    Commands:
-        The commands (and their signatures) that the capability defines.
 
     {#- First iterate through the capabilities to create a quick reference table #}
     {% for capability in capabilities %}
@@ -153,7 +149,7 @@ Capabilities Reference
     {%- if capability['command'] is a_list %}
     {#- for each command, print its name method signature followed by its description #}
     {%- for command in capability['command'] %}
-      *{{ command['@name'] }}({% if command['argument'] %}{% if command['argument'] is a_list %}{% for arg in command['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}, {% endfor %}{% else %}{{ command['argument']['@type'] }} {{ command['argument']['@name'] }}{% endif %}{% endif %}):*
+      *{{ command['@name'] }}({% if command['argument'] %}{% if command['argument'] is a_list %}{% for arg in command['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}{{ command['argument']['@type'] }} {{ command['argument']['@name'] }}{% endif %}{% endif %}):*
         {%- if properties[referenceName][referenceName+".cmd."+command['@name']+".description"] %}
           {{ properties[referenceName][referenceName+".cmd."+command['@name']+".description"] }}
         {% else %}
@@ -239,7 +235,7 @@ Capabilities Reference
     {#- handle case if we only have one command and it wasn't a list in the dict #}
     {%- else %}
     {#- for this command, print its name method signature followed by its description #}
-      *{{ capability['command']['@name'] }}({% if capability['command']['argument'] %}{% if capability['command']['argument'] is a_list %}{% for arg in capability['command']['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}, {% endfor %}{% else %}{{ capability['command']['argument']['@type'] }} {{ capability['command']['argument']['@name'] }}{% endif %}{% endif %}):*
+      *{{ capability['command']['@name'] }}({% if capability['command']['argument'] %}{% if capability['command']['argument'] is a_list %}{% for arg in capability['command']['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}{{ capability['command']['argument']['@type'] }} {{ capability['command']['argument']['@name'] }}{% endif %}{% endif %}):*
       {%- if properties[referenceName][referenceName+".cmd."+capability['command']['@name']+".description"] %}
         {{ properties[referenceName][referenceName+".cmd."+capability['command']['@name']+".description"] }}
       {% endif %}


### PR DESCRIPTION
-fix the weird spacing for color control and music player attributes in jinja template (this was the SmartThingCapabilities repo fix)
-get rid of tailing ',' character in params list for commands.
-Get rid of unnecessary table columns
-Alphabetize the table