### PR TITLE
[DOCS-418] Add a note on lowercase directory names

### DIFF
--- a/tools-and-ide/github-integration.rst
+++ b/tools-and-ide/github-integration.rst
@@ -151,6 +151,10 @@ The namespace is typically your GitHub user name.
 When you create a SmartApp or device handler in the IDE, you provide a namespace, which is then populated in the definition method.
 This namespace will be used in the directory structure as shown above.
 
+.. important::
+
+    Note that the directory names must all be lowercase and must be consistent with the namespace and the name of the Device Handler or SmartApp. In other words, the directory names must all be lowercase with non-alphanumeric characters replaced with a dash. For example, if a SmartApp has the namespace "My Apps" and the name "My First App" then the path name for it must be ``smartapps/my-apps/my-first-app.src/my-first-app.groovy``.
+
 .. _github_ide_tour:
 
 GitHub Integration IDE Tour


### PR DESCRIPTION
A 3rd party developer asked the question if the directory names need to be in lowercase for the GitHub integration to work. See here: https://github.com/SmartThingsCommunity/Documentation/issues/514
The answer is yes and this PR is to add the clarification to the docs.