### PR TITLE
some minor visual changes to capabilities reference template

### DIFF
--- a/capabilities-reference.rst
+++ b/capabilities-reference.rst
@@ -88,11 +88,12 @@ Capabilities Reference
     {{ properties[referenceName][referenceName+".description"] }}
     {%- endif %}
     {# Capability preference reference #}
-    **Preferences Reference:**
-    {{ ("capability."+referenceName)|indent(2, true) }}
+    Preferences Reference
+    ^^^^^^^^^^^^^^^^^^^^^
+    {{ ("``capability."+referenceName+"``")|indent(2, true) }}
     {# Capability attributes section #}
-    **Attributes:**
-    ^^^^^^^^^^^^^^^
+    Attributes
+    ^^^^^^^^^^
     {% if capability['attribute'] %}
     {#- check if the attribute key in dict is a list. It will not be a list if there is only one attribute #}
     {%- if capability['attribute'] is a_list %}
@@ -167,14 +168,14 @@ Capabilities Reference
     {%- endif %}
 
     {# Capability commands section #}
-    **Commands:**
-    ^^^^^^^^^^^^^
+    Commands
+    ^^^^^^^^
     {% if capability['command'] %}
     {#- check if the command key in dict is a list. It will not be a list if there is only one command #}
     {%- if capability['command'] is a_list %}
     {#- for each command, print its name method signature followed by its description #}
     {%- for command in capability['command'] %}
-      *{{ command['@name'] }}({% if command['argument'] %}{% if command['argument'] is a_list %}{% for arg in command['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}{{ command['argument']['@type'] }} {{ command['argument']['@name'] }}{% endif %}{% endif %}):*
+      *{{ command['@name'] }}({% if command['argument'] %}{% if command['argument'] is a_list %}{% for arg in command['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}{{ command['argument']['@type'] }} {{ command['argument']['@name'] }}{% endif %}{% endif %})*
         {%- if properties[referenceName][referenceName+".cmd."+command['@name']+".description"] %}
           {{ properties[referenceName][referenceName+".cmd."+command['@name']+".description"] }}
         {% else %}
@@ -260,7 +261,7 @@ Capabilities Reference
     {#- handle case if we only have one command and it wasn't a list in the dict #}
     {%- else %}
     {#- for this command, print its name method signature followed by its description #}
-      *{{ capability['command']['@name'] }}({% if capability['command']['argument'] %}{% if capability['command']['argument'] is a_list %}{% for arg in capability['command']['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}{{ capability['command']['argument']['@type'] }} {{ capability['command']['argument']['@name'] }}{% endif %}{% endif %}):*
+      *{{ capability['command']['@name'] }}({% if capability['command']['argument'] %}{% if capability['command']['argument'] is a_list %}{% for arg in capability['command']['argument'] %}{{ arg['@type'] }} {{ arg['@name'] }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}{{ capability['command']['argument']['@type'] }} {{ capability['command']['argument']['@name'] }}{% endif %}{% endif %})*
       {%- if properties[referenceName][referenceName+".cmd."+capability['command']['@name']+".description"] %}
         {{ properties[referenceName][referenceName+".cmd."+capability['command']['@name']+".description"] }}
       {% endif %}


### PR DESCRIPTION
Some minor UX changes to the template:

- Removed the trailing `:` from "Attributes" and "Commands" section headers, since section headers by convention do not have a trailing colon.
- Removed bold styling from "Attributes" and "Commands" since it is already a section header.
- Made "Preferences Reference" its own section for each capability, so it appears in the side navigation along with Attributes and Commands, and looks consistent with them.
- Removed trailing colon from the command name, since the indentation for the definition is enough to notify the reader that the definition follows.

Before:

![image](https://cloud.githubusercontent.com/assets/276225/21018763/b9c76b26-bd33-11e6-9263-cad86c0500b1.png)

With Changes:

![image](https://cloud.githubusercontent.com/assets/276225/21018792/d7a5938e-bd33-11e6-98fa-f38c1747cd22.png)

I'm open to discussing these changes if people don't like them. @unixbeast also please review in case there is some negative impact with modifying the template as I have that I'm not aware of.