### PR TITLE
fix broken links

### DIFF
--- a/smartapp-developers-guide/devices.rst
+++ b/smartapp-developers-guide/devices.rst
@@ -273,8 +273,8 @@ See Also
 --------
 
  - :ref:`capabilities_taxonomy`
- - `Preferences and Settings <preferences-and-settings>`__
- - `Events and Subscriptions <simple-event-handler-smartapps.html>`__
+ - :ref:`prefs_and_settings`
+ - :ref:`events_and_subscriptions`
  - :ref:`device_ref` API Documentation
  - :ref:`event_ref` API Documentation
  - :ref:`state_ref` API Documentation


### PR DESCRIPTION
address issue raised in #501 but uses the `:ref:` target instead of relying on html target