### PR TITLE
[DOCS-446] Add getLastActivityDate and getStatus to Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This documentation is written using [reStructuredText](http://docutils.sourcefor
 Follow these steps to build the documentation locally:
 
 1. [Install virtualenv](https://virtualenv.pypa.io/en/latest/installation.html).
-2. Create an isolated environment: `virtualenv --no-site-packages .venv`
+2. Create an isolated environment in a different location than the Documentation directory: `virtualenv --no-site-packages .venv`
 3. Activate the environment: `source .venv/bin/activate`
 4. Install dependencies: `(.venv)~/Documentation$ pip install -r requirements.txt`
 5. Build HTML: `(.venv)~/Documentation$ make html`

--- a/ref-docs/device-ref.rst
+++ b/ref-docs/device-ref.rst
@@ -464,6 +464,19 @@ The name of the Device set by the user in the mobile application or Web IDE.
 
 ----
 
+getLastActivity()
+-----------------
+
+The date of the last event with a source of ``device``. (i.e. not commands)
+
+**Signature:**
+    ``String getLastActivity()``
+
+**Returns:**
+    `Date`_ - Date of the last event with a source of ``device``.
+
+----
+
 .. _device_ref_manufacturer_name:
 
 getManufacturerName()
@@ -525,6 +538,19 @@ Not applicable for cloud or LAN-connected devices (``null`` will be returned).
             log.debug "switch id: ${it.id}, model name: ${it.getModelName()}"
         }
     }
+
+----
+
+getStatus()
+-----------
+
+Get the current status of the Device. If no status is found then ``INACTIVE`` is returned.
+
+**Signature:**
+    ``String getStatus()``
+
+**Returns:**
+    `String`_ - the status of the Device or ``INACTIVE`` if one doesn't exist.
 
 ----
 


### PR DESCRIPTION
These methods are currently undocumented - adding docs:
getLastActivity returns the date of the last event with a source of 'Device'

getStatus returns the status of the device - i.e. ONLINE, ACTIVE, INACTIVE.. if the device doesn't have a status then INACTIVE will be returned.