### PR TITLE
Use button instead of tooltip for copy code

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -108,230 +108,30 @@ div.column {
     background: #ff4d4d;
 }
 
-.highlight .copy-btn {
-    background: url('../images/clippy.svg') no-repeat;
-    background-size: 20px 20px;
-    width: 20px;
-    height: 20px;
-    -o-transition: opacity 0.3s ease-in-out;
-    transition: opacity 0.3s ease-in-out;
-    opacity: 0;
-    padding: 2px 6px;
+.highlight .copy-to-clipboard {
     position: absolute;
-    right: 0;
-    top: 0;
-    display: inline-block;
-    font-size: 13px;
-    font-weight: bold;
-    line-height: 20px;
-    color: #333;
-    white-space: nowrap;
-    vertical-align: middle;
-    cursor: pointer;
-    background-color: #eee;
-    border: 0px;
-    border-radius: 0px 0px 0px 3px;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    -webkit-appearance: none
-}
-
-.copy-btn:focus {
-    text-decoration: none;
-    border-color: #51a7e8;
-    outline: none;
-    box-shadow: 0 0 5px rgba(81,167,232,0.5)
-}
-
-.copy-btn:focus:hover,.copy-btn.selected:focus {
-    border-color: #51a7e8
-}
-
-.copy-btn:hover,.copy-btn:active,.copy-btn.zeroclipboard-is-hover,.copy-btn.zeroclipboard-is-active {
-    text-decoration: none;
-    background-color: #ddd;
-    /*background-image: linear-gradient(#eee,#ddd);*/
-    border-color: #ccc
-}
-
-.copy-btn:active,.copy-btn.selected,.copy-btn.zeroclipboard-is-active {
-    background-color: #dcdcdc;
-    background-image: none;
-    border-color: #b5b5b5;
-    box-shadow: inset 0 2px 4px rgba(0,0,0,0.15)
-}
-
-.copy-btn.selected:hover {
-    background-color: #cfcfcf
-}
-
-.copy-btn:disabled,.copy-btn:disabled:hover,.copy-btn.disabled,.copy-btn.disabled:hover {
-    color: rgba(102,102,102,0.5);
-    cursor: default;
-    background-color: rgba(229,229,229,0.5);
-    background-image: none;
-    border-color: rgba(197,197,197,0.5);
-    box-shadow: none
-}
-
-.highlight:hover .copy-btn {
-    opacity: 1;
-}
-
-/* tooltip styles from from Primer (http://primercss.io/tooltips/) */
-.tooltipped {
-    position: relative
-}
-
-.tooltipped:after {
-    position: absolute;
-    z-index: 1000000;
-    display: none;
-    padding: 5px 8px;
-    font: normal normal 11px/1.5 Helvetica,arial,nimbussansl,liberationsans,freesans,clean,sans-serif,"Segoe UI Emoji","Segoe UI Symbol";
-    color: #fff;
+    right: 0px;
+    top: 0px;
+    background-color: #4d5257;
+    color: #ccc;
+    border-radius: 2px;
+    width: 80px;
+    height: 30px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
     text-align: center;
-    text-decoration: none;
-    text-shadow: none;
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: break-word;
-    white-space: pre;
-    pointer-events: none;
-    content: attr(aria-label);
-    background: rgba(0,0,0,0.8);
-    border-radius: 3px;
-    -webkit-font-smoothing: subpixel-antialiased
+    vertical-align: middle;
+    padding-top: 6px;
+    font-size: 14px;
+    opacity: 0.5;
 }
 
-.tooltipped:before {
-    position: absolute;
-    z-index: 1000001;
-    display: none;
-    width: 0;
-    height: 0;
-    color: rgba(0,0,0,0.8);
-    pointer-events: none;
-    content: "";
-    border: 5px solid transparent
+.copy-active, .copy-to-clipboard:hover {
+  opacity: 1 !important;
 }
 
-.tooltipped:hover:before,.tooltipped:hover:after,.tooltipped:active:before,.tooltipped:active:after,.tooltipped:focus:before,.tooltipped:focus:after {
-    display: inline-block;
-    text-decoration: none
-}
-
-.tooltipped-multiline:hover:after,.tooltipped-multiline:active:after,.tooltipped-multiline:focus:after {
-    display: table-cell
-}
-
-.tooltipped-s:after,.tooltipped-se:after,.tooltipped-sw:after {
-    top: 100%;
-    right: 50%;
-    margin-top: 5px
-}
-
-.tooltipped-s:before,.tooltipped-se:before,.tooltipped-sw:before {
-    top: auto;
-    right: 50%;
-    bottom: -5px;
-    margin-right: -5px;
-    border-bottom-color: rgba(0,0,0,0.8)
-}
-
-.tooltipped-se:after {
-    right: auto;
-    left: 50%;
-    margin-left: -15px
-}
-
-.tooltipped-sw:after {
-    margin-right: -15px
-}
-
-.tooltipped-n:after,.tooltipped-ne:after,.tooltipped-nw:after {
-    right: 50%;
-    bottom: 100%;
-    margin-bottom: 5px
-}
-
-.tooltipped-n:before,.tooltipped-ne:before,.tooltipped-nw:before {
-    top: -5px;
-    right: 50%;
-    bottom: auto;
-    margin-right: -5px;
-    border-top-color: rgba(0,0,0,0.8)
-}
-
-.tooltipped-ne:after {
-    right: auto;
-    left: 50%;
-    margin-left: -15px
-}
-
-.tooltipped-nw:after {
-    margin-right: -15px
-}
-
-.tooltipped-s:after,.tooltipped-n:after {
-    -webkit-transform: translateX(50%);
-    -ms-transform: translateX(50%);
-    transform: translateX(50%)
-}
-
-.tooltipped-w:after {
-    right: 100%;
-    bottom: 50%;
-    margin-right: 5px;
-    -webkit-transform: translateY(50%);
-    -ms-transform: translateY(50%);
-    transform: translateY(50%)
-}
-
-.tooltipped-w:before {
-    top: 50%;
-    bottom: 50%;
-    left: -5px;
-    margin-top: -5px;
-    border-left-color: rgba(0,0,0,0.8)
-}
-
-.tooltipped-e:after {
-    bottom: 50%;
-    left: 100%;
-    margin-left: 5px;
-    -webkit-transform: translateY(50%);
-    -ms-transform: translateY(50%);
-    transform: translateY(50%)
-}
-
-.tooltipped-e:before {
-    top: 50%;
-    right: -5px;
-    bottom: 50%;
-    margin-top: -5px;
-    border-right-color: rgba(0,0,0,0.8)
-}
-
-.tooltipped-multiline:after {
-    width: -webkit-max-content;
-    width: -moz-max-content;
-    width: max-content;
-    max-width: 250px;
-    word-break: break-word;
-    word-wrap: normal;
-    white-space: pre-line;
-    border-collapse: separate
-}
-
-.tooltipped-multiline.tooltipped-s:after,.tooltipped-multiline.tooltipped-n:after {
-    right: auto;
-    left: 50%;
-    -webkit-transform: translateX(-50%);
-    -ms-transform: translateX(-50%);
-    transform: translateX(-50%)
+.copy-to-clipboard:hover {
+  cursor: pointer;
 }
 
 /* overrides for dark monokai theme */

--- a/_static/javascript/copycode.js
+++ b/_static/javascript/copycode.js
@@ -2,31 +2,34 @@
 // and parts of Primer for tooltip support
 var copyCode = {
   init: function() {
-    $('.highlight').each(function() {
-      $(this).prepend('<button class="copy-btn" data-clipboard-snippet></button>');
+    $('.highlight pre').each(function() {
+      var code = $(this);
+      code.after('<span class="copy-to-clipboard">Copy</span>');
+      code.on('mouseenter', function() {
+        var copyBlock = $(this).next('.copy-to-clipboard');
+        copyBlock.addClass('copy-active');
+      });
+      code.on('mouseleave', function() {
+        var copyBlock = $(this).next('.copy-to-clipboard');
+        copyBlock.removeClass('copy-active');
+        copyBlock.html("Copy");
+      });
     });
-    var clipboardSnippets = new Clipboard('[data-clipboard-snippet]',{
-      target: function(trigger) {
-        return trigger.nextElementSibling;
-      }
-    });
-    clipboardSnippets.on('success', function(e) {
-      e.clearSelection();
-      copyCode.showTooltip(e.trigger, 'Copied to clipboard');
-    });
-    clipboardSnippets.on('error', function(e) {
-      copyCode.showTooltip(e.trigger, copyCode.fallbackMessage());
-    });
+    var text, clip = new Clipboard('.copy-to-clipboard', {
+        text: function(trigger) {
+          return $(trigger).prev('pre').text();
+        }
+      });
 
-    $('.copy-btn').each(function() {
-      $(this).mouseenter(function() {
-        copyCode.showTooltip(this, 'Click to copy');
+      clip.on('success', function(e) {
+        e.clearSelection();
+        console.log("copied!");
+        $(e.trigger).html("Copied!");
       });
-      $(this).mouseleave(function() {
-        $(this).removeAttr('aria-label');
-        $(this).removeClass('tooltipped tooltipped-nw');
+
+      clip.on('error', function(e) {
+        console.log("error: " + e);
       });
-    });
   },
 
   showTooltip: function(elem, msg) {


### PR DESCRIPTION
Use a copy button instead of an icon with tooltips. 

Allows us to remove a bunch of tooltip CSS and the UX is more streamlined as a result.

Before:

![image](https://cloud.githubusercontent.com/assets/276225/22701538/7f61de2e-ed23-11e6-9867-27f4b54d537e.png)

After:

![image](https://cloud.githubusercontent.com/assets/276225/22701573/967cea72-ed23-11e6-96f1-fc1b36509a6b.png)
