### PR TITLE
[DOCS-458] Style updates for titles and section headings only

### DIFF
--- a/architecture/index.rst
+++ b/architecture/index.rst
@@ -18,7 +18,7 @@ This allows you to develop an application for a type of device, regardless of th
 All of the code that developers can write on our platform is written in Groovy, which is a dynamic, object-oriented language built for the Java platform.
 You can learn more about Groovy on the :ref:`groovy-basics` page.
 
-Big Picture
+Big picture
 -----------
 
 .. TODO: I think we need a nicer looking picture. (Jesse O'Neill-Oine)
@@ -56,7 +56,7 @@ This allows for certain automations to continue, even without AC power.
 It also ships with USB ports and is Bluetooth Low Energy capable.
 While not active at launch, this allows for greater expansion in the future without requiring new hardware.
 
-Connectivity Management
+Connectivity management
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Connectivity Management is the layer that connects your SmartThings Hub, the client devices (mobile phones) to SmartThings servers and to the cloud as a whole.
@@ -67,7 +67,7 @@ The Connectivity Management layer is comprised of:
 
 These are the highways by which your messages are sent to the internet.
 
-Device Handler Execution
+Device Handler execution
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The SmartThings system determines what type of device you are using based on Device Handlers.
@@ -75,14 +75,14 @@ Once the Device Handler is selected, the incoming messages are parsed by that pa
 The input to the Device Handler is a set of device-specific messages, and the output of the Device Handler is normalized SmartThings events.
 Note that one message can lead to many SmartThings events.
 
-Subscription Management
+Subscription management
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 When events are created in the SmartThings platform, they don't inherently do anything besides publish that they've happened.
 Instead of events triggering change, SmartApps are configured with subscriptions that listen for defined events.
 The purpose of the subscription management layer is to match up events that are triggered by the Device Handlers with the SmartApp that is using them.
 
-SmartApp Execution
+SmartApp execution
 ^^^^^^^^^^^^^^^^^^
 
 The SmartApp is run when triggered either via subscriptions, or via external calls to SmartApp endpoints, or by scheduled methods.
@@ -98,10 +98,10 @@ You have full control of the configuration, including editing, adding, removing,
 To create, you write code within the IDE for SmartApps and Device Handlers.
 SmartThings also has an integrated simulator that allows you to simulate any devices, so it's not required to own the devices you develop for.
 
-Important Concepts
+Important concepts
 ------------------
 
-Asynchronous and Eventually Consistent Programming
+Asynchronous and eventually consistent programming
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When dealing with the physical graph, i.e., a digital representation of the physical things connected around us, there will always be a delay between when you request something to happen and when it actually happens.
@@ -142,7 +142,7 @@ Accounts are the top-level container that represents the SmartThings ‘customer
 Accounts contain only Locations and no other types of
 objects.
 
-Locations and Users
+Locations and users
 ^^^^^^^^^^^^^^^^^^^
 
 Locations are meant to represent a geolocation such as “Home” or “Office”.
@@ -160,7 +160,7 @@ Further, nesting of groups is not currently supported.
 
 ----
 
-Capability Taxonomy
+Capability taxonomy
 -------------------
 
 Capabilities represent the common taxonomy that allows SmartThings platform to link SmartApps with Device Handlers.
@@ -171,7 +171,7 @@ The :ref:`capabilities_taxonomy` is evolving and is heavily influenced by existi
 Capabilities themselves may be decomposed into both ‘Actions’ or ‘Commands’ (these are synonymous), and Attributes.
 Actions represent ways in which you can control or actuate the device, whereas Attributes represent state information or properties of the device.
 
-Attributes and Events
+Attributes and events
 ^^^^^^^^^^^^^^^^^^^^^
 
 Attributes represent the various properties or characteristics of a device.
@@ -187,13 +187,13 @@ A capability is supported by a specific set of commands.
 For example, the ‘Switch’ capability has two required commands: ‘On’ and ‘Off’.
 When a device supports a specific capability, it must generally support all of the commands required of that capability.
 
-Custom Capabilities
+Custom capabilities
 ^^^^^^^^^^^^^^^^^^^
 
 We do not currently support creating custom capabilities.
 You can, however, create a device-type handler that exposes custom commands or attributes.
 
-SmartThings Cloud
+SmartThings cloud
 -----------------
 
 The SmartThings platform assumes a "Cloud First” approach.
@@ -221,17 +221,17 @@ These devices may not be connected to a SmartThings Hub, and instead are directl
 
 Put simply, if there is no Hub, then the SmartApps layer must run in the cloud!
 
-**Scenario: SmartApps May Run Across both Cloud and Hub Connected Devices**
+**Scenario: SmartApps may run across both cloud- and Hub-connected devices**
 
 As a corollary to the first point above, since there are use cases where devices are not hub-connected, SmartApps might be installed to use one device that is hub-connected, and another device that is cloud-connected, all in the same app.
 In this case, the SmartApp needs to run in the cloud.
 
-**Scenario: There may be Multiple Hubs**
+**Scenario: There may be multiple Hubs**
 
 While the mesh network standards for ZigBee and Z-Wave generally eliminate the need for multiple SmartThings Hubs, we didn’t want to exclude this as a valid deployment configuration for large homes or even business applications of our technology.
 In the multi-hub case, SmartApps that use multiple devices that are split across hubs will run in the cloud in order to simplify the complexity of application deployment.
 
-**Scenario: External Service Integration**
+**Scenario: External service integration**
 
 SmartApps may call external web services.
 Calling them from SmartThings cloud reduces risk as it allows SmartThings to easily monitor for errors and ensure the security and privacy of the users.
@@ -268,7 +268,7 @@ Before starting your development, you must note that:
 
     If for some reason you are not seeing your hub in the IDE, then from *My Locations* page select the location and it will prompt you to log into correct shard where you can see your hub.
 
-Consequences of Sharding
+Consequences of sharding
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 In practice, some consequences of sharding are:

--- a/publishing/index.rst
+++ b/publishing/index.rst
@@ -8,14 +8,14 @@ Publishing for distribution requires you to submit your SmartApp or Device Handl
 
 .. _publishing-for-yourself:
 
-For Yourself
+For yourself
 ------------
 
 When you publish for yourself, your SmartApp or Device Handler is available *only to your account* on your SmartThings mobile app.
 
 .. _ensure-proper-location:
 
-Ensure Proper Location
+Ensure proper Location
 ^^^^^^^^^^^^^^^^^^^^^^
 
 To publish your SmartApp or Device Handler properly, you must be at the proper Location *before* you begin writing your code.
@@ -52,7 +52,7 @@ Tap on the *My Apps* category at the bottom and you will see your SmartApp.
 
 .. _publishing-for-distribution:
 
-For Public Distribution
+For public distribution
 -----------------------
 
 To publish your SmartApp or Device Handler for public distribution, you will need to submit it for review and approval by SmartThings.
@@ -62,7 +62,7 @@ Follow these steps:
 - From this page click on *+New Request*. This will take you to *Submit a SmartApp or device type for publication* page.
 - Follow the instructions on this page to submit your SmartApp or Device Handler for review by SmartThings.
 
-Review Process
+Review process
 --------------
 
 SmartThings team will review your SmartApp or Device Handler for approval.

--- a/ratelimits/index.rst
+++ b/ratelimits/index.rst
@@ -10,12 +10,12 @@ Rate limits apply to SmartApps, Device Handlers, and Web Services SmartApps.
 
 -----
 
-SmartApp and Device Handler Rate Limits
+SmartApp and Device Handler rate limits
 ---------------------------------------
 
 SmartApps and Device Handlers are monitored for excessive resource utilization on two measures: **Execution Time Limits** and **Execution Count Limits.**
 
-Execution Time Limits
+Execution time limits
 ^^^^^^^^^^^^^^^^^^^^^
 
 - Methods are limited to a continuous execution time of 20 seconds.
@@ -24,13 +24,13 @@ Execution Time Limits
 
 If these limits are exceeded, the current execution will be suspended.
 
-Execution Count Limits
+Execution count limits
 ^^^^^^^^^^^^^^^^^^^^^^
 
 A SmartApp or a Device Handler is limited to no more than 250 executions in 60 seconds. If the limit of 250 executions is reached in a 60-second time window, no further executions will occur until the next time window. A log entry will be created for the SmartApp or the Device Handler that was rate limited. The count will start over when the current time window closes and the next time window begins.
 
-Ways to Avoid Hitting SmartApp and Device Handler Rate Limits
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Ways to avoid hitting rate limits
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A common cause for exceeding the 250 executions within 60 seconds limit is excessive subscriptions that might result in an infinite loop of events. For example, subscribing to an “on” and “off” event and the “on” command triggers the “off” event and vice versa - leading to a never-ending chain of event handlers being called. It is also possible that a SmartApp that subscribes to a very large number of particularly “chatty” devices may run into this limit. Making sure that your SmartApp subscriptions are not excessive in number will help avoid hitting the rate limit.
 
@@ -40,7 +40,7 @@ Similarly, a Device Handler may exceed Rate Limit when it sends many commands to
 
 .. _web_services_rate_limiting:
 
-Web Services SmartApps Rate Limits
+Web services SmartApps rate limits
 ----------------------------------
 
 SmartApps or Device Handlers that expose their web services APIs are limited to receiving 250 requests in a single 60-second time window.
@@ -48,7 +48,7 @@ SmartApps or Device Handlers that expose their web services APIs are limited to 
 There are various headers available on every request that provide information about the current rate limit limits for a given installed SmartApp or Device Handler. These are discussed further below.
 
 
-Rate Limit Headers
+Rate limit headers
 ^^^^^^^^^^^^^^^^^^
 
 The SmartThings platform will set three HTTP headers on the response for every inbound API call, so that a client may understand the current rate limiting status:
@@ -63,13 +63,13 @@ The SmartThings platform will set three HTTP headers on the response for every i
    The time remaining in the current rate limit window. In this example, there is 58 seconds remaining before the current rate limit window resets.
 
 
-Rate Limit HTTP Status Code
+Rate limit HTTP status code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In addition to the three HTTP headers above, when the rate limit has been exceeded, the HTTP status code of 429 will be sent on the response, as shown below.
 
 
-Rate Limit Error Handling
+Rate limit error handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following error may be returned by the SmartThings platform when a Rate Limit is hit:
@@ -84,7 +84,7 @@ HTTP Response Code          Error Message                                       
 
 .. _sms_rate_limits:
 
-SMS Rate Limits
+SMS rate limits
 ---------------
 
 No more than 15 SMS messages may be sent to the same number per minute.


### PR DESCRIPTION
Updated styles for titles and section headings only for three guides: 
1) Architecture, 
2) Rate Limits and 
3) Publishing Code.

@jimmyjames Please check. Also I went with "cloud" instead of "Cloud," and "Web services" instead of "Web Services," as a trial before we decide which way to standardize. 