### PR TITLE
Fix unclickable nav links

### DIFF
--- a/_static/css/sphinx_override.css
+++ b/_static/css/sphinx_override.css
@@ -7252,8 +7252,7 @@ footer span.commit .rst-content tt,
   display: none;
 }
 
-.smartthingsNav ul,
-.smartthingsNav:active ul {
+.smartthingsNav ul {
   display: none;
   opacity: 0;
   max-height: 300px;


### PR DESCRIPTION
# Overview

Fixing regression with nav links above a viewport width of 768px. The entire `<ul>` was being displaced off-screen when the parent div was in the `:active` state.