### PR TITLE
Fix output of "make html"

### DIFF
--- a/_theme/sphinx_rtd_theme/theme.conf
+++ b/_theme/sphinx_rtd_theme/theme.conf
@@ -1,6 +1,5 @@
 [theme]
 inherit = basic
-stylesheet = css/theme.css
 
 [options]
 typekit_id = hiw1hhg

--- a/conf.py
+++ b/conf.py
@@ -194,7 +194,7 @@ html_favicon = 'favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
## what this addresses
According to notable issues such as [sphinx-doc/sphinx #2090](https://github.com/sphinx-doc/sphinx/issues/2090), there's an issue with the appropriate files not being copied from `_static` into the `_build/html` directory. Evidently this is not a problem with a regular ol' ReadTheDocs build because it seems to do something other than `make html`. 

#### Main fix
In `conf.py`, add the line `html_static_path = ['_static']`, which was previously commented out and had no value at all. 

#### Secondary fix
When using `make html`, the output seemed to include a reference to `css/theme.css`, which was configured in `sphinx_rtd_theme/theme.conf`, but it was never actually used in the actual RTD site (take a look in dev tools [here](https://docs.smartthings.com/en/latest/), `theme.css` is never requested). Since we were entirely overriding the sphinx theme, I just removed the line from that config. *Let me know if this seems okay,* @jimmyjames. 

## commits
```
Add '_static' to html_static_path
Remove reference to unused theme.css
    sphinx_rtd_theme/theme.conf
```

## preview 👍 
Local output of `make html` produces an `index.html` which loads like this in Chrome 71:
![image](https://user-images.githubusercontent.com/1534259/50352928-495ba500-050c-11e9-90d2-0ae2bcbb7003.png)
